### PR TITLE
Changed #defines to deal with older versions of gcc such that they don't

### DIFF
--- a/src/zmqpp/compatibility.hpp
+++ b/src/zmqpp/compatibility.hpp
@@ -36,11 +36,11 @@
 #define ZMQ_EXPERIMENTAL_LABELS
 #endif
 
-// Currently if your not using gcc or it's a major version other than 4 you'll have to deal with it yourself
-#ifdef __GNUC__
+// Deal with older versions of gcc
+#if defined(__GNUC__) and !defined(__clang__)
 #if __GNUC__ == 4
 
-// Deal with older compilers not supporting C++0x typesafe enum class name {} comparison
+// Deal with older gcc not supporting C++0x typesafe enum class name {} comparison
 #if __GNUC_MINOR__ < 4
 #define ZMQPP_COMPARABLE_ENUM enum
 #endif
@@ -52,20 +52,20 @@
 #endif // if __GNUC_PATCHLEVEL__ < 1
 #endif // if __GNUC_MINOR__ == 4
 
-// Deal with older compilers not supporting C++0x lambda function
+// Deal with older gcc not supporting C++0x lambda function
 #if __GNUC_MINOR__ < 5
 #define ZMQPP_IGNORE_LAMBDA_FUNCTION_TESTS
 #define ZMQPP_EXPLICITLY_DELETED
 #endif // if __GNUC_MINOR__ < 5
 
-// Deal with older compilers not supporting C++0x nullptr
+// Deal with older gcc not supporting C++0x nullptr
 #if __GNUC_MINOR__ < 6
 #define nullptr NULL
 #define noexcept
 #endif // if __GNUC_MINOR__ < 6
 
 #endif // if __GNUC_ == 4
-#endif // if __GNUC_
+#endif // if defined(__GNUC__) && !defined(__clang__)
 
 // Generic state, assume a modern compiler
 #ifndef ZMQPP_COMPARABLE_ENUM


### PR DESCRIPTION
Changed #defines to deal with older versions of gcc such that they don't
apply to code that includes zmqpp.hpp. This allows code compiled with clang 3.4
to include zmqpp.hpp without getting lots of errors.
