### PR TITLE
Add support for ZMQ_IMMEDIATE

### DIFF
--- a/src/tests/test_socket_options.cpp
+++ b/src/tests/test_socket_options.cpp
@@ -198,9 +198,11 @@ BOOST_AUTO_TEST_CASE( set_socket_options )
 #endif
 
 #if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MINOR == 2)
 	CHECK_SET(socket, bool, delay_attach_on_connect);
-	CHECK_SET(socket, bool, router_mandatory);
-	CHECK_SET(socket, bool, xpub_verbose);
+#else
+	CHECK_SET(socket, bool, immediate);
+#endif
 	// CHECK_SET(socket, int, tcp_keepalive);  --- special case of boolean but with -1?
 	CHECK_SET(socket, int, tcp_keepalive_idle);
 	CHECK_SET(socket, int, tcp_keepalive_count);
@@ -265,8 +267,12 @@ BOOST_AUTO_TEST_CASE( get_socket_options )
 #endif
 
 #if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
-	CHECK_GET(socket, std::string, last_endpoint);
+#if (ZMQ_VERSION_MINOR == 2)
 	CHECK_GET(socket, bool, delay_attach_on_connect);
+#else
+	CHECK_GET(socket, bool, immediate);
+#endif
+	CHECK_GET(socket, std::string, last_endpoint);
 	CHECK_GET(socket, int, tcp_keepalive);
 	CHECK_GET(socket, int, tcp_keepalive_idle);
 	CHECK_GET(socket, int, tcp_keepalive_count);

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -343,7 +343,11 @@ void socket::set(socket_option const& option, int const& value)
 	case socket_option::multicast_loopback:
 #endif
 #if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MINOR == 2)
 	case socket_option::delay_attach_on_connect:
+#else
+	case socket_option::immediate:
+#endif
 	case socket_option::router_mandatory:
 	case socket_option::xpub_verbose:
 #endif
@@ -409,12 +413,22 @@ void socket::set(socket_option const& option, bool const& value)
 	case socket_option::ipv4_only:
 #endif
 #if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MINOR == 2)
 	case socket_option::delay_attach_on_connect:
+#else
+	case socket_option::immediate:
+#endif
 	case socket_option::router_mandatory:
 	case socket_option::xpub_verbose:
 #endif
-		zmq_setsockopt(_socket, static_cast<int>(option), &value, sizeof(value));
+	{
+		int ivalue = value ? 1 : 0;
+		if (0 != zmq_setsockopt(_socket, static_cast<int>(option), &ivalue, sizeof(ivalue)))
+		{
+			throw zmq_internal_exception();
+		}
 		break;
+	}
 	default:
 		throw exception("attempting to set a non boolean option with a boolean value");
 	}
@@ -521,7 +535,11 @@ void socket::get(socket_option const& option, int& value) const
 	case socket_option::ipv4_only:
 #endif
 #if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MINOR == 2)
 	case socket_option::delay_attach_on_connect:
+#else
+	case socket_option::immediate:
+#endif
 	case socket_option::tcp_keepalive:
 	case socket_option::tcp_keepalive_idle:
 	case socket_option::tcp_keepalive_count:
@@ -563,7 +581,11 @@ void socket::get(socket_option const& option, bool& value) const
 	case socket_option::ipv4_only:
 #endif
 #if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MINOR == 2)
 	case socket_option::delay_attach_on_connect:
+#else
+	case socket_option::immediate:
+#endif
 #endif
 #ifdef ZMQ_EXPERIMENTAL_LABELS
 	case socket_option::receive_label:

--- a/src/zmqpp/socket_options.hpp
+++ b/src/zmqpp/socket_options.hpp
@@ -55,7 +55,12 @@ enum class socket_option {
 	ipv4_only                 = ZMQ_IPV4ONLY,
 #endif
 #if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MINOR == 2)
 	delay_attach_on_connect   = ZMQ_DELAY_ATTACH_ON_CONNECT, /*!< Delay buffer attachment until connect complete */
+#else
+	//  ZMQ_DELAY_ATTACH_ON_CONNECT is renamed in ZeroMQ starting 3.3.x
+	immediate                 = ZMQ_IMMEDIATE,               /*!< Block message sending until connect complete */
+#endif
 	last_endpoint             = ZMQ_LAST_ENDPOINT,           /*!< Last bound endpoint - get only */
 	router_mandatory          = ZMQ_ROUTER_MANDATORY,        /*!< Require routable messages - set only */
 	xpub_verbose              = ZMQ_XPUB_VERBOSE,            /*!< Pass on existing subscriptions - set only */


### PR DESCRIPTION
Add support for ZMQ_IMMEDIATE

Fix for a bug with boolean socket options, when it's impossible to set
a value for a boolean option because sizes of bool and int types
differ on some platforms

Delete tests for router_mandatory and xpub_verbose, because they are not
applicable for subscribe sockets
