### PR TITLE
Add packaging scripts for buildable SRPMs in Fedora

### DIFF
--- a/packaging/build-srpm
+++ b/packaging/build-srpm
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+PKG_NAME=zmqpp
+t=`dirname ${BASH_SOURCE}`
+PKG_VERSION=`cat ${t}/../CHANGES.md  | grep ^Version | head -n 1 | awk -F" " '{print $2}'`
+PKG_RELEASE=`git log --pretty="%ai" -n 1 | tr -d ':' | tr ' \-+:' '....'  | cut -c1-17`
+PKG_RELEASE=${PKG_RELEASE}.git`git log --pretty="%h" -n 1`
+OUTPUT_DIRECTORY=
+
+syntax() {
+    echo "build-srpm -o [output directory]"
+}
+
+while getopts "o:" o; do
+    case "${o}" in
+        o)
+        OUTPUT_DIRECTORY=${OPTARG}
+            ;;
+        *)
+            syntax
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$OUTPUT_DIRECTORY" ] ; then
+    echo error: no output directory specified
+    echo
+    syntax
+    exit 1
+fi
+
+if [ ! -d ${OUTPUT_DIRECTORY} ] ; then
+    echo "error: output directory doesn't exist"
+    exit 1
+fi
+
+TARGET_DIR=`mktemp --tmpdir -d XXXXXXrpm-packaging`
+
+_prepare_srpm() {
+    mkdir -p ${TARGET_DIR}/SPECS || return 1
+    mkdir -p ${TARGET_DIR}/SOURCES || return 1
+    git archive --format tar.gz --prefix=${PKG_NAME}-${PKG_VERSION}/ HEAD > \
+	${TARGET_DIR}/SOURCES/${PKG_NAME}-${PKG_VERSION}.tar.gz || return 1
+    cat ${t}/${PKG_NAME}.spec | sed s/PKG_VERSION/${PKG_VERSION}/g \
+       | sed s/PKG_RELEASE/${PKG_RELEASE}/g > ${TARGET_DIR}/SPECS/${PKG_NAME}.spec || return 1
+    rpmbuild -bs --define "_topdir ${TARGET_DIR}" ${TARGET_DIR}/SPECS/${PKG_NAME}.spec || return 1
+    return 0
+}
+
+if _prepare_srpm; then
+    cp -a ${TARGET_DIR}/SRPMS/* ${OUTPUT_DIRECTORY}
+fi
+
+rm -rf ${TARGET_DIR}

--- a/packaging/zmqpp.spec
+++ b/packaging/zmqpp.spec
@@ -1,0 +1,62 @@
+Name:           zmqpp
+Version:        PKG_VERSION
+Release:        PKG_RELEASE%{?dist}
+Summary:        0mq 'highlevel' C++ bindings
+Group:          System Environment/Libraries
+License:        LGPLv3
+URL:            https://github.com/zeromq/zmqpp
+Source0:        %{name}-%{version}.tar.gz
+BuildRoot:      %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+BuildRequires:  gcc-c++
+BuildRequires:  zeromq3-devel
+BuildRequires:  boost-devel
+
+%description
+This C++ binding for 0mq/zmq is a 'high-level' library that hides most of
+the c-style interface core 0mq provides. It consists of a number of header
+and source files all residing in the zmq directory, these files are provided
+under the MIT license (see LICENCE for details).
+
+%package        devel
+Summary:        Development files for %{name}
+Group:          Development/Libraries
+Requires:       %{name} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and header files for
+developing applications that use %{name}.
+
+%prep
+%setup -q
+
+%build
+make %{?_smp_mflags}
+
+%check
+make check
+
+%install
+
+rm -rf ${RPM_BUILD_ROOT}
+mkdir -p ${RPM_BUILD_ROOT}%{_libdir}
+mkdir -p ${RPM_BUILD_ROOT}%{_includedir}/zmqpp
+make install \
+    PREFIX=/usr \
+    DESTDIR=${RPM_BUILD_ROOT} \
+    LIBDIR=${RPM_BUILD_ROOT}%{_libdir} \
+    INCLUDEDIR=${RPM_BUILD_ROOT}%{_includedir}
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/libzmqpp.*
+
+%files devel
+%defattr(-,root,root,-)
+%{_includedir}/zmqpp/*


### PR DESCRIPTION
Under a git clone of this package, simply run:

```
 ./packaging/build-srpm -o .
```

It will generate a Source RPM of HEAD that can be built locally
using rpmbuild or mock, or under Fedora's build servers.

For example, an build-srpm run has generated:

```
  zmqpp-3.2.0-2014.03.15.155954.git1b629f8.fc20.src.rpm
```

Subsequently, an rpmbuild run generated:

```
  zmqpp-3.2.0-2014.03.15.155954.git1b629f8.fc20.src.rpm
  zmqpp-3.2.0-2014.03.15.155954.git1b629f8.fc20.x86_64.rpm
  zmqpp-debuginfo-3.2.0-2014.03.15.155954.git1b629f8.fc20.x86_64.rpm
  zmqpp-devel-3.2.0-2014.03.15.155954.git1b629f8.fc20.x86_64.rpm
```

Tested with Fedora 20.

Signed-off-by: Dan Aloni dan@kernelim.com
