### PR TITLE
Allow building zmqpp with Microsoft Visual Studio

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Author: Pieter Hintjens <ph@imatix.com>
 Author: Rob Hubbard <rob.hubbard@datasift.com>
 Author: Dinka Ranns <dinka.ranns@gmail.com>
 Author: Olaf Lenz <olenz@icp.uni-stuttgart.de>
+Author: Krzysztof Rapacki <shauren.dev@gmail.com>

--- a/src/tests/test_context.cpp
+++ b/src/tests/test_context.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE( validaty )
 
 BOOST_AUTO_TEST_CASE( throws_exception )
 {
-#if (ZMQ_VERSION_MAJOR < 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR < 2))
+#if (ZMQ_VERSION_MAJOR < 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR < 2))
 	BOOST_CHECK_THROW(new zmqpp::context(-1), zmqpp::zmq_internal_exception);
 #else
 	zmqpp::context context;

--- a/src/tests/test_load.cpp
+++ b/src/tests/test_load.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE( push_messages_baseline )
 
 #if (ZMQ_VERSION_MAJOR == 2)
 		zmq_recv(puller, &message, 0);
-#elif (ZMQ_VERSION_MAJOR < 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR < 2))
+#elif (ZMQ_VERSION_MAJOR < 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR < 2))
 		zmq_recvmsg(puller, &message, 0);
 #else
 		zmq_msg_recv(&message, puller, 0);

--- a/src/tests/test_socket_options.cpp
+++ b/src/tests/test_socket_options.cpp
@@ -99,7 +99,7 @@ void check_set(zmqpp::socket& socket, zmqpp::socket_option const& option, std::s
 	// Unsigned 64bit integer
 	try_set<uint64_t, Type>(socket, option, 1, option_name, "unsigned 64bit integer");
 
-#if (ZMQ_VERSION_MAJOR == 2) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR < 2))
+#if (ZMQ_VERSION_MAJOR == 2) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR < 2))
 	// 64bit integer
 	try_set<int64_t, Type>(socket, option, 1, option_name, "signed 64bit integer");
 #endif
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE( set_socket_options )
 	CHECK_NOSET(socket, file_descriptor);
 	CHECK_NOSET(socket, events);
 	CHECK_NOSET(socket, type);
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 	CHECK_NOSET(socket, last_endpoint);
 #endif
 
@@ -193,11 +193,11 @@ BOOST_AUTO_TEST_CASE( set_socket_options )
 	CHECK_SET(socket, uint64_t, high_water_mark);
 #endif
 
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 1))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 1))
 	CHECK_SET(socket, bool, ipv4_only);
 #endif
 
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 #if (ZMQ_VERSION_MINOR == 2)
 	CHECK_SET(socket, bool, delay_attach_on_connect);
 #else
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE( get_socket_options )
 
 	CHECK_NOGET(socket, subscribe);
 	CHECK_NOGET(socket, unsubscribe);
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 	CHECK_NOGET(socket, router_mandatory);
 	CHECK_NOGET(socket, xpub_verbose);
 	CHECK_NOGET(socket, tcp_accept_filter);
@@ -262,11 +262,11 @@ BOOST_AUTO_TEST_CASE( get_socket_options )
 	CHECK_GET(socket, uint64_t, high_water_mark);
 #endif
 
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 1))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 1))
 	CHECK_GET(socket, bool, ipv4_only);
 #endif
 
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 #if (ZMQ_VERSION_MINOR == 2)
 	CHECK_GET(socket, bool, delay_attach_on_connect);
 #else

--- a/src/zmqpp/compatibility.hpp
+++ b/src/zmqpp/compatibility.hpp
@@ -27,17 +27,17 @@
 #define ZMQPP_REQUIRED_ZMQ_MAJOR 2
 #define ZMQPP_REQUIRED_ZMQ_MINOR 2
 
-#if (ZMQ_VERSION_MAJOR < ZMQPP_REQUIRED_ZMQ_MAJOR) or ((ZMQ_VERSION_MAJOR == ZMQPP_REQUIRED_ZMQ_MAJOR) and (ZMQ_VERSION_MINOR < ZMQPP_REQUIRED_ZMQ_MINOR))
+#if (ZMQ_VERSION_MAJOR < ZMQPP_REQUIRED_ZMQ_MAJOR) || ((ZMQ_VERSION_MAJOR == ZMQPP_REQUIRED_ZMQ_MAJOR) && (ZMQ_VERSION_MINOR < ZMQPP_REQUIRED_ZMQ_MINOR))
 #error zmqpp requires a later version of 0mq
 #endif
 
 // Experimental feature support
-#if (ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR == 0)
+#if (ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR == 0)
 #define ZMQ_EXPERIMENTAL_LABELS
 #endif
 
 // Deal with older versions of gcc
-#if defined(__GNUC__) and !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__)
 #if __GNUC__ == 4
 
 // Deal with older gcc not supporting C++0x typesafe enum class name {} comparison
@@ -61,11 +61,23 @@
 // Deal with older gcc not supporting C++0x nullptr
 #if __GNUC_MINOR__ < 6
 #define nullptr NULL
-#define noexcept
+#define NOEXCEPT
 #endif // if __GNUC_MINOR__ < 6
 
 #endif // if __GNUC_ == 4
 #endif // if defined(__GNUC__) && !defined(__clang__)
+
+#if defined(_MSC_VER)
+#define NOEXCEPT throw()
+#if _MSC_VER < 1800
+#define ZMQPP_EXPLICITLY_DELETED
+#endif // if _MSC_VER < 1800
+#if _MSC_VER < 1600
+#define nullptr NULL
+#define ZMQPP_IGNORE_LAMBDA_FUNCTION_TESTS
+#define ZMQPP_COMPARABLE_ENUM enum
+#endif // if _MSC_VER < 1600
+#endif // if defined(_MSC_VER)
 
 // Generic state, assume a modern compiler
 #ifndef ZMQPP_COMPARABLE_ENUM
@@ -74,6 +86,10 @@
 
 #ifndef ZMQPP_EXPLICITLY_DELETED
 #define ZMQPP_EXPLICITLY_DELETED = delete
+#endif
+
+#ifndef NOEXCEPT
+#define NOEXCEPT noexcept
 #endif
 
 #endif /* ZMQPP_COMPATIBILITY_HPP_ */

--- a/src/zmqpp/context.cpp
+++ b/src/zmqpp/context.cpp
@@ -15,7 +15,7 @@ void context::terminate()
 	int result;
 	do
 	{
-#if (ZMQ_VERSION_MAJOR < 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR < 2))
+#if (ZMQ_VERSION_MAJOR < 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR < 2))
 		result = zmq_term(_context);
 #else
 		result = zmq_ctx_destroy(_context);
@@ -25,7 +25,7 @@ void context::terminate()
 	_context = nullptr;
 }
 
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 void context::set(context_option const option, int const value)
 {
 	if (nullptr == _context) { throw invalid_instance("context is invalid"); }

--- a/src/zmqpp/context.hpp
+++ b/src/zmqpp/context.hpp
@@ -14,7 +14,7 @@
 
 #include "compatibility.hpp"
 #include "exception.hpp"
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 #include "context_options.hpp"
 #endif
 
@@ -38,7 +38,7 @@ class context
 {
 public:
 
-#if (ZMQ_VERSION_MAJOR < 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR < 2))
+#if (ZMQ_VERSION_MAJOR < 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR < 2))
 	/*!
 	 * Initialise the 0mq context.
 	 *
@@ -64,7 +64,7 @@ public:
 #endif
 		: _context(nullptr)
 	{
-#if (ZMQ_VERSION_MAJOR < 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR < 2))
+#if (ZMQ_VERSION_MAJOR < 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR < 2))
 		_context = zmq_init(threads);
 #else
 		_context = zmq_ctx_new();
@@ -84,7 +84,7 @@ public:
 	 * If there are open sockets will block while zmq internal buffers are
 	 * processed up to a limit specified by that sockets linger option.
 	 */
-	~context() noexcept
+	~context() NOEXCEPT
 	{
 		if (nullptr != _context)
 		{
@@ -99,7 +99,7 @@ public:
 	 *
 	 * \param source a rvalue instance of the object who's internals we wish to steal.
 	 */
-	context(context&& source) noexcept
+	context(context&& source) NOEXCEPT
 		: _context(source._context)
 	{
 		source._context = nullptr;
@@ -112,7 +112,7 @@ public:
 	 *
 	 * \param source an rvalue instance of the context who's internals we wish to steal.
 	 */
-	context& operator=(context&& source) noexcept
+	context& operator=(context&& source) NOEXCEPT
 	{
 		std::swap( _context, source._context );
 		return *this;
@@ -128,7 +128,7 @@ public:
 	 */
 	void terminate();
 
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 	/*!
 	 * Set the value of an option in the underlaying zmq context.
 	 *
@@ -156,7 +156,7 @@ public:
 	 *
 	 * \return boolean true if the object is valid.
 	 */
-	operator bool() const noexcept
+	operator bool() const NOEXCEPT
 	{
 		return nullptr != _context;
 	}
@@ -166,7 +166,7 @@ public:
 	 *
 	 * \return void pointer to the underlying 0mq context.
 	 */
-	operator void*() const noexcept
+	operator void*() const NOEXCEPT
 	{
 		return _context;
 	}
@@ -176,7 +176,7 @@ private:
 
 	// No copy - private and not implemented
 	context(context const&) ZMQPP_EXPLICITLY_DELETED;
-	context& operator=(context const&) noexcept ZMQPP_EXPLICITLY_DELETED;
+	context& operator=(context const&) NOEXCEPT ZMQPP_EXPLICITLY_DELETED;
 };
 
 }

--- a/src/zmqpp/frame.hpp
+++ b/src/zmqpp/frame.hpp
@@ -49,8 +49,8 @@ private:
 	zmq_msg_t _msg;
 
 	// Disable implicit copy support, code must request a copy to clone
-	frame(frame const&) noexcept ZMQPP_EXPLICITLY_DELETED;
-	frame& operator=(frame const&) noexcept ZMQPP_EXPLICITLY_DELETED;
+	frame(frame const&) NOEXCEPT ZMQPP_EXPLICITLY_DELETED;
+	frame& operator=(frame const&) NOEXCEPT ZMQPP_EXPLICITLY_DELETED;
 };
 
 } // namespace zmqpp

--- a/src/zmqpp/inet.hpp
+++ b/src/zmqpp/inet.hpp
@@ -10,7 +10,11 @@
 
 /** \todo cross-platform version of including headers. */
 // We get htons and htonl from here
+#ifdef _WIN32
+#include <WinSock2.h>
+#else
 #include <netinet/in.h>
+#endif
 
 #include "compatibility.hpp"
 
@@ -62,8 +66,6 @@ inline uint64_t swap_if_needed(uint64_t const value_to_check)
 	std::swap(value.bytes[3], value.bytes[4]);
 
 	return value.integer;
-}
-
 }
 
 /*!
@@ -140,7 +142,7 @@ inline double htond(double value)
 
 	uint64_t temp;
 	memcpy(&temp, &value, sizeof(uint64_t));
-	temp = htonll( temp );
+	temp = zmqpp::htonll(temp);
 	memcpy(&value, &temp, sizeof(uint64_t));
 
 	return value;
@@ -158,10 +160,12 @@ inline double ntohd(double value)
 
 	uint64_t temp;
 	memcpy(&temp, &value, sizeof(uint64_t));
-	temp = ntohll( temp );
+	temp = zmqpp::ntohll(temp);
 	memcpy(&value, &temp, sizeof(uint64_t));
 
 	return value;
+}
+
 }
 
 #endif /* INET_HPP_ */

--- a/src/zmqpp/message.cpp
+++ b/src/zmqpp/message.cpp
@@ -138,7 +138,7 @@ void message::get(int64_t& integer, size_t const part) const
 	assert(sizeof(int64_t) == size(part));
 
 	uint64_t const* network_order = static_cast<uint64_t const*>(raw_data(part));
-	integer = static_cast<int64_t>(htonll(*network_order));
+	integer = static_cast<int64_t>(zmqpp::htonll(*network_order));
 }
 
 void message::get(uint8_t& unsigned_integer, size_t const part) const
@@ -170,7 +170,7 @@ void message::get(uint64_t& unsigned_integer, size_t const part) const
 	assert(sizeof(uint64_t) == size(part));
 
 	uint64_t const* network_order = static_cast<uint64_t const*>(raw_data(part));
-	unsigned_integer = ntohll(*network_order);
+	unsigned_integer = zmqpp::ntohll(*network_order);
 }
 
 void message::get(float& floating_point, size_t const part) const
@@ -178,7 +178,7 @@ void message::get(float& floating_point, size_t const part) const
 	assert(sizeof(float) == size(part));
 
 	float const* network_order = static_cast<float const*>(raw_data(part));
-	floating_point = ntohf(*network_order);
+	floating_point = zmqpp::ntohf(*network_order);
 }
 
 void message::get(double& double_precision, size_t const part) const
@@ -186,7 +186,7 @@ void message::get(double& double_precision, size_t const part) const
 	assert(sizeof(double) == size(part));
 
 	double const* network_order = static_cast<double const*>(raw_data(part));
-	double_precision = ntohd(*network_order);
+	double_precision = zmqpp::ntohd(*network_order);
 }
 
 void message::get(bool& boolean, size_t const part) const
@@ -228,7 +228,7 @@ message& message::operator<<(int32_t const integer)
 
 message& message::operator<<(int64_t const integer)
 {
-	uint64_t network_order = htonll(static_cast<uint64_t>(integer));
+	uint64_t network_order = zmqpp::htonll(static_cast<uint64_t>(integer));
 	add(reinterpret_cast<void const*>(&network_order), sizeof(uint64_t));
 
 	return *this;
@@ -259,7 +259,7 @@ message& message::operator<<(uint32_t const unsigned_integer)
 
 message& message::operator<<(uint64_t const unsigned_integer)
 {
-	uint64_t network_order = htonll(unsigned_integer);
+	uint64_t network_order = zmqpp::htonll(unsigned_integer);
 	add(reinterpret_cast<void const*>(&network_order), sizeof(uint64_t));
 
 	return *this;
@@ -269,7 +269,7 @@ message& message::operator<<(float const floating_point)
 {
 	assert(sizeof(float) == 4);
 
-	float network_order = htonf(floating_point);
+	float network_order = zmqpp::htonf(floating_point);
 	add(&network_order, sizeof(float));
 
 	return *this;
@@ -279,7 +279,7 @@ message& message::operator<<(double const double_precision)
 {
 	assert(sizeof(double) == 8);
 
-	double network_order = htond(double_precision);
+	double network_order = zmqpp::htond(double_precision);
 	add(&network_order, sizeof(double));
 
 	return *this;
@@ -329,7 +329,7 @@ void message::push_front(int32_t const integer)
 
 void message::push_front(int64_t const integer)
 {
-	uint64_t network_order = htonll(static_cast<uint64_t>(integer));
+	uint64_t network_order = zmqpp::htonll(static_cast<uint64_t>(integer));
 	push_front(&network_order, sizeof(uint64_t));
 }
 
@@ -353,7 +353,7 @@ void message::push_front(uint32_t const unsigned_integer)
 
 void message::push_front(uint64_t const unsigned_integer)
 {
-	uint64_t network_order = htonll(unsigned_integer);
+	uint64_t network_order = zmqpp::htonll(unsigned_integer);
 	push_front(&network_order, sizeof(uint64_t));
 }
 
@@ -361,7 +361,7 @@ void message::push_front(float const floating_point)
 {
 	assert(sizeof(float) == 4);
 
-	float network_order = htonf(floating_point);
+	float network_order = zmqpp::htonf(floating_point);
 	push_front(&network_order, sizeof(float));
 }
 
@@ -369,7 +369,7 @@ void message::push_front(double const double_precision)
 {
 	assert(sizeof(double) == 8);
 
-	double network_order = htond(double_precision);
+	double network_order = zmqpp::htond(double_precision);
 	push_front(&network_order, sizeof(double));
 }
 
@@ -399,14 +399,14 @@ void message::pop_back()
 	_parts.pop_back();
 }
 
-message::message(message&& source) noexcept
+message::message(message&& source) NOEXCEPT
 	: _parts()
 	, _read_cursor(0)
 {
 	std::swap(_parts, source._parts);
 }
 
-message& message::operator=(message&& source) noexcept
+message& message::operator=(message&& source) NOEXCEPT
 {
 	std::swap(_parts, source._parts);
 	return *this;

--- a/src/zmqpp/message.hpp
+++ b/src/zmqpp/message.hpp
@@ -131,7 +131,7 @@ public:
 	void add(Type *part, size_t const size)
 	{
 		_parts.push_back( frame( part, size ) );
-	};
+	}
 
 
 	template<typename Type, typename ...Args>
@@ -214,8 +214,8 @@ public:
 	void remove(size_t const part);
 
 	// Move supporting
-	message(message&& source) noexcept;
-	message& operator=(message&& source) noexcept;
+	message(message&& source) NOEXCEPT;
+	message& operator=(message&& source) NOEXCEPT;
 
 	// Copy support
 	message copy() const;
@@ -236,8 +236,8 @@ private:
 	size_t _read_cursor;
 
 	// Disable implicit copy support, code must request a copy to clone
-	message(message const&) noexcept ZMQPP_EXPLICITLY_DELETED;
-	message& operator=(message const&) noexcept ZMQPP_EXPLICITLY_DELETED;
+	message(message const&) NOEXCEPT ZMQPP_EXPLICITLY_DELETED;
+	message& operator=(message const&) NOEXCEPT ZMQPP_EXPLICITLY_DELETED;
 
 	static void release_callback(void* data, void* hint);
 

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -16,11 +16,15 @@
 namespace zmqpp
 {
 
-const int socket::normal;
-const int socket::dont_wait;
-const int socket::send_more;
+const int socket::normal = 0;
+#if (ZMQ_VERSION_MAJOR == 2)
+const int socket::dont_wait = ZMQ_NOBLOCK;
+#else
+const int socket::dont_wait = ZMQ_DONTWAIT;
+#endif
+const int socket::send_more = ZMQ_SNDMORE;
 #ifdef ZMQ_EXPERIMENTAL_LABELS
-const int socket::send_label;
+const int socket::send_label = ZMQ_SNDLABEL;
 #endif
 
 const int max_socket_option_buffer_size = 256;
@@ -127,7 +131,7 @@ bool socket::send(message& message, bool const dont_block /* = false */)
 
 #if (ZMQ_VERSION_MAJOR == 2)
 		int result = zmq_send( _socket, &message.raw_msg(i), flag );
-#elif (ZMQ_VERSION_MAJOR < 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR < 2))
+#elif (ZMQ_VERSION_MAJOR < 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR < 2))
 		int result = zmq_sendmsg( _socket, &message.raw_msg(i), flag );
 #else
 		int result = zmq_msg_send( &message.raw_msg(i), _socket, flag );
@@ -187,7 +191,7 @@ bool socket::receive(message& message, bool const dont_block /* = false */)
 	{
 #if (ZMQ_VERSION_MAJOR == 2)
 		int result = zmq_recv( _socket, &_recv_buffer, flags );
-#elif (ZMQ_VERSION_MAJOR < 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR < 2))
+#elif (ZMQ_VERSION_MAJOR < 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR < 2))
 		int result = zmq_recvmsg( _socket, &_recv_buffer, flags );
 #else
 		int result = zmq_msg_recv( &_recv_buffer, _socket, flags );
@@ -237,7 +241,7 @@ bool socket::receive(std::string& string, int const flags /* = NORMAL */)
 {
 #if (ZMQ_VERSION_MAJOR == 2)
 		int result = zmq_recv( _socket, &_recv_buffer, flags );
-#elif (ZMQ_VERSION_MAJOR < 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR < 2))
+#elif (ZMQ_VERSION_MAJOR < 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR < 2))
 		int result = zmq_recvmsg( _socket, &_recv_buffer, flags );
 #else
 		int result = zmq_msg_recv( &_recv_buffer, _socket, flags );
@@ -297,7 +301,7 @@ bool socket::receive_raw(char* buffer, int& length, int const flags /* = NORMAL 
 {
 #if (ZMQ_VERSION_MAJOR == 2)
 		int result = zmq_recv( _socket, &_recv_buffer, flags );
-#elif (ZMQ_VERSION_MAJOR < 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR < 2))
+#elif (ZMQ_VERSION_MAJOR < 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR < 2))
 		int result = zmq_recvmsg( _socket, &_recv_buffer, flags );
 #else
 		int result = zmq_msg_recv( &_recv_buffer, _socket, flags );
@@ -366,13 +370,13 @@ void socket::set(socket_option const option, int const value)
 		break;
 
 	// Boolean
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 1))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 1))
 	case socket_option::ipv4_only:
 #endif
 #if (ZMQ_VERSION_MAJOR == 2)
 	case socket_option::multicast_loopback:
 #endif
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 #if (ZMQ_VERSION_MINOR == 2)
 	case socket_option::delay_attach_on_connect:
 #else
@@ -387,7 +391,7 @@ void socket::set(socket_option const option, int const value)
 		break;
 
 	// Default or Boolean
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 	case socket_option::tcp_keepalive:
 		if (value < -1 || value > 1) { throw exception("attempting to set a default or boolean option with a non -1, 0 or 1 integer"); }
 		if (0 != zmq_setsockopt(_socket, static_cast<int>(option), &value, sizeof(value)))
@@ -417,7 +421,7 @@ void socket::set(socket_option const option, int const value)
 	case socket_option::linger:
 	case socket_option::receive_timeout:
 	case socket_option::send_timeout:
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 	case socket_option::tcp_keepalive_idle:
 	case socket_option::tcp_keepalive_count:
 	case socket_option::tcp_keepalive_interval:
@@ -439,10 +443,10 @@ void socket::set(socket_option const option, bool const value)
 #if (ZMQ_VERSION_MAJOR == 2)
 	case socket_option::multicast_loopback:
 #endif
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 1))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 1))
 	case socket_option::ipv4_only:
 #endif
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 #if (ZMQ_VERSION_MINOR == 2)
 	case socket_option::delay_attach_on_connect:
 #else
@@ -516,7 +520,7 @@ void socket::set(socket_option const option, char const* value, size_t const len
 	case socket_option::identity:
 	case socket_option::subscribe:
 	case socket_option::unsubscribe:
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 	case socket_option::tcp_accept_filter:
 #endif
 		if (0 != zmq_setsockopt(_socket, static_cast<int>(option), value, length))
@@ -561,10 +565,10 @@ void socket::get(socket_option const option, int& value) const
 	case socket_option::receive_high_water_mark:
 	case socket_option::multicast_hops:
 #endif
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 1))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 1))
 	case socket_option::ipv4_only:
 #endif
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 #if (ZMQ_VERSION_MINOR == 2)
 	case socket_option::delay_attach_on_connect:
 #else
@@ -607,10 +611,10 @@ void socket::get(socket_option const option, bool& value) const
 #if (ZMQ_VERSION_MAJOR == 2)
 	case socket_option::multicast_loopback:
 #endif
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 1))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 1))
 	case socket_option::ipv4_only:
 #endif
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 #if (ZMQ_VERSION_MINOR == 2)
 	case socket_option::delay_attach_on_connect:
 #else
@@ -688,7 +692,7 @@ void socket::get(socket_option const option, std::string& value) const
 	switch(option)
 	{
 	case socket_option::identity:
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 	case socket_option::last_endpoint:
 #endif
 		if(0 != zmq_getsockopt(_socket, static_cast<int>(option), buffer.data(), &size))
@@ -703,7 +707,7 @@ void socket::get(socket_option const option, std::string& value) const
 	}
 }
 
-socket::socket(socket&& source) noexcept
+socket::socket(socket&& source) NOEXCEPT
 	: _socket(source._socket)
 	, _type(source._type)
 	, _recv_buffer()
@@ -717,7 +721,7 @@ socket::socket(socket&& source) noexcept
 	source._socket = nullptr;
 }
 
-socket& socket::operator=(socket&& source) noexcept
+socket& socket::operator=(socket&& source) NOEXCEPT
 {
 	std::swap(_socket, source._socket);
 

--- a/src/zmqpp/socket.hpp
+++ b/src/zmqpp/socket.hpp
@@ -45,15 +45,15 @@ typedef message     message_t;
 class socket
 {
 public:
-	static const int normal     = 0;            /*!< /brief default send type, no flags set */
+	static const int normal;                    /*!< /brief default send type, no flags set */
 #if (ZMQ_VERSION_MAJOR == 2)
-	static const int dont_wait  = ZMQ_NOBLOCK;  /*!< /brief don't block if sending is not currently possible  */
+	static const int dont_wait;				    /*!< /brief don't block if sending is not currently possible  */
 #else
-	static const int dont_wait  = ZMQ_DONTWAIT; /*!< /brief don't block if sending is not currently possible  */
+	static const int dont_wait;					/*!< /brief don't block if sending is not currently possible  */
 #endif
-	static const int send_more  = ZMQ_SNDMORE;  /*!< /brief more parts will follow this one */
+	static const int send_more;					/*!< /brief more parts will follow this one */
 #ifdef ZMQ_EXPERIMENTAL_LABELS
-	static const int send_label = ZMQ_SNDLABEL; /*!< /brief this message part is an internal zmq label */
+	static const int send_label;				/*!< /brief this message part is an internal zmq label */
 #endif
 
 	/*!
@@ -450,7 +450,7 @@ public:
 	 *
 	 * \param source target socket to steal internals from
 	 */
-	socket(socket&& source) noexcept;
+	socket(socket&& source) NOEXCEPT;
 
 	/*!
 	 * Move operator
@@ -463,7 +463,7 @@ public:
 	 * \param source target socket to steal internals from
 	 * \return socket reference to this
 	 */
-	socket& operator=(socket&& source) noexcept;
+	socket& operator=(socket&& source) NOEXCEPT;
 
 	/*!
 	 * Check the socket is still valid
@@ -489,8 +489,8 @@ private:
 	zmq_msg_t _recv_buffer;
 
 	// No copy
-	socket(socket const&) noexcept ZMQPP_EXPLICITLY_DELETED;
-	socket& operator=(socket const&) noexcept ZMQPP_EXPLICITLY_DELETED;
+	socket(socket const&) NOEXCEPT ZMQPP_EXPLICITLY_DELETED;
+	socket& operator=(socket const&) NOEXCEPT ZMQPP_EXPLICITLY_DELETED;
 
 	void track_message(message_t const&, uint32_t const, bool&);
 };

--- a/src/zmqpp/socket_options.hpp
+++ b/src/zmqpp/socket_options.hpp
@@ -51,10 +51,10 @@ enum class socket_option {
 	receive_high_water_mark   = ZMQ_RCVHWM,            /*!< High-water mark for inbound messages */
 	multicast_hops            = ZMQ_MULTICAST_HOPS,    /*!< Maximum number of multicast hops */
 #endif
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 1))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 1))
 	ipv4_only                 = ZMQ_IPV4ONLY,
 #endif
-#if (ZMQ_VERSION_MAJOR > 3) or ((ZMQ_VERSION_MAJOR == 3) and (ZMQ_VERSION_MINOR >= 2))
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 #if (ZMQ_VERSION_MINOR == 2)
 	delay_attach_on_connect   = ZMQ_DELAY_ATTACH_ON_CONNECT, /*!< Delay buffer attachment until connect complete */
 #else


### PR DESCRIPTION
Changed preprocessor if directives to use || and && operators instead of words "and"/"or"
Replaced noexcept definition (if not supported) with NOEXCEPT - C++11 standard forbids defining keywords and MSVC checks that even if the keyword is not implemented (checks since version 12 (2013))
Moved socket flags to source file to prevent linker warnings about duplicate definitions
Moved inet functions into zmqpp namespace to resolve overload conflicts with system functions - windows provides an overload different only by return type and that is forbidden in C++

Signed-off-by: Krzysztof Rapacki shauren.dev@gmail.com
