### PR TITLE
Fix crash on sending a std::string larger than 2GB

### DIFF
--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -264,7 +264,7 @@ bool socket::receive(std::string& string, int const flags /* = NORMAL */)
 }
 
 
-bool socket::send_raw(char const* buffer, int const length, int const flags /* = NORMAL */)
+bool socket::send_raw(char const* buffer, size_t const length, int const flags /* = NORMAL */)
 {
 #if (ZMQ_VERSION_MAJOR == 2)
     zmq_msg_t msg;

--- a/src/zmqpp/socket.hpp
+++ b/src/zmqpp/socket.hpp
@@ -215,7 +215,7 @@ public:
 	 * \param flags message send flags
 	 * \return true if message part sent, false if it would have blocked
 	 */
-	bool send_raw(char const* buffer, int const length, int const flags = normal);
+	bool send_raw(char const* buffer, size_t const length, int const flags = normal);
 
 	/*!
 	 * \warning If the buffer is not large enough for the message part then the


### PR DESCRIPTION
The socket::send(std::string) function calls send_raw which has a signed integer
as the buffer length. With messages larger than 2GB this causes the size_t
passed to ZMQ to be a large positive value near
std::numeric_limits<size_t>::max(). On 64-bit systems this causes memory
allocation to fail because it is so large.

This is fixed by changing send_raw to take a size_t instead of an int for the
buffer length.
