### PR TITLE
Bug in zmqpp::reactor

### DIFF
--- a/src/zmqpp/reactor.hpp
+++ b/src/zmqpp/reactor.hpp
@@ -36,7 +36,7 @@ namespace zmqpp
          * Any sockets will need to be closed separately.
          */
         ~reactor();
-
+	
         /*!
          * Add a socket to the reactor, providing a handler that will be called when the monitored events occur.
          *
@@ -148,7 +148,17 @@ namespace zmqpp
 
     private:
         std::vector<PollItemCallablePair> items_;
-        poller poller_;
+        std::vector<const socket_t *> sockRemoveLater_;
+        std::vector<int> fdRemoveLater_;
+      
+      /**
+       * Flush the fdRemoveLater_ and sockRemoveLater_ vector, effectively removing
+       * the item for the reactor and poller.
+       */
+      void flush_remove_later();
+
+      poller poller_;
+      bool dispatching_;
     };
 
 }


### PR DESCRIPTION
Hello,
I submitted a PR (#47) that was merged (thank you). However, I didn't do much testing and spotted a bug.

Problem:
- Calling `remove()`modify the watched item vector. Doing so from an handler means we remove element from a vector while iterating over it (see `zmqpp::reactor::poll`). This is wrong.

Fix:
- This add two vectors that store items are to be removed. Those vector are "flushed" (meaning the items are effectively removed from the reactor and poller) in the `poll()` method. 
- Calling remove from a handler will cause a delayed removable, and will not cause incorrect behavior.

Does that seems right?
