### PR TITLE
zmqpp::actor

### DIFF
--- a/src/tests/test_actor.cpp
+++ b/src/tests/test_actor.cpp
@@ -1,0 +1,219 @@
+
+#include <boost/test/unit_test.hpp>
+#include <thread>
+
+#include "zmqpp/context.hpp"
+#include "zmqpp/message.hpp"
+#include "zmqpp/actor.hpp"
+#include "zmqpp/poller.hpp"
+#include <iostream>
+
+BOOST_AUTO_TEST_SUITE( actor )
+
+
+BOOST_AUTO_TEST_CASE(simple_test)
+{
+    auto lambda = [](zmqpp::socket * pipe)
+    {
+        zmqpp::message msg("boap");
+        msg.add(42);
+        msg.add(13);
+        pipe->send(zmqpp::signal::ok); // signal we successfully started
+        pipe->send(msg);
+        return true; // will send signal::ok to signal successful shutdown
+    };
+    zmqpp::actor actor(lambda);
+
+
+    zmqpp::message msg;
+    actor.pipe()->receive(msg);
+    int a, b;
+    std::string str;
+
+    msg >> str >> a >> b;
+    BOOST_CHECK_EQUAL("boap", str);
+    BOOST_CHECK_EQUAL(42, a);
+    BOOST_CHECK_EQUAL(13, b);
+}
+
+BOOST_AUTO_TEST_CASE(child_thread_wait_for_stop)
+{
+    auto lambda = [](zmqpp::socket * pipe)
+    {
+        int count = 0;
+        zmqpp::message msg;
+        zmqpp::signal sig;
+        pipe->send(zmqpp::signal::ok);
+
+        while (pipe->receive(msg))
+        {
+            if (msg.is_signal())
+            {
+                msg.get(sig, 0);
+                if (sig == zmqpp::signal::stop)
+                    break;
+            }
+            zmqpp::message rep("hello");
+            pipe->send(rep);
+            count++;
+        }
+        zmqpp::message final_res;
+        final_res << count;
+        // send the total count to the parent thread
+        pipe->send(final_res);
+        return true;
+    };
+    zmqpp::actor *actor = new zmqpp::actor(lambda);
+    zmqpp::message msg;
+
+    for (int i = 0; i < 12; i++)
+    {
+        actor->pipe()->send("hey");
+        actor->pipe()->receive(msg);
+    }
+    actor->stop(); // sends the stop signal, but doesn't wait for a response: the destructor will wait instead
+    actor->pipe()->receive(msg);
+    int count;
+    msg >> count;
+    delete actor;
+    BOOST_CHECK_EQUAL(12, count);
+}
+
+/**
+ * Helper function that runs a echo server (router socket) bound to endpoint.
+ * It will send signal::ko if the bind fails (invalid endpoint) and signal::ok if initialization worked.
+ * 
+ * It exits when receiving signal::stop from the pipe, and send the number of messages the router sent
+ * when receiving the GET_COUNT command.
+ */
+static bool count_echo_server(zmqpp::socket * pipe, zmqpp::context *context, std::string endpoint)
+{
+    zmqpp::socket router(*context, zmqpp::socket_type::router);
+    zmqpp::poller p;
+    zmqpp::signal sig;
+    int count = 0; // how many message sent (by the router))
+
+    try
+    {
+        router.bind(endpoint);
+        pipe->send(zmqpp::signal::ok);
+    }
+    catch (zmqpp::zmq_internal_exception &e)
+    {
+        // by returning false here, the actor will send signal::ko
+        // this will make the actor constructor throw.
+        // we could also to the ourselves: pipe->send(signal::ko);)
+        return false;
+    }
+
+    p.add(*pipe);
+    p.add(router);
+    while (p.poll())
+    {
+        zmqpp::message msg;
+        if (p.has_input(router))
+        {
+            router.receive(msg);
+            router.send(msg);
+            count++;
+        }
+        if (p.has_input(*pipe))
+        {
+            pipe->receive(msg);
+            if (msg.is_signal())
+            {
+                msg.get(sig, 0);
+                if (sig == zmqpp::signal::stop)
+                    break;
+            }
+            if (msg.get(0) == "GET_COUNT")
+            {
+                zmqpp::message msg_count(count);
+                pipe->send(msg_count);
+            }
+        }
+    }
+    return true;
+}
+
+BOOST_AUTO_TEST_CASE(test_actor_init_failed)
+{
+    zmqpp::context application_context; // what would be the default context we use generally.
+
+    // the actor thread will fail and send signal::ko, so actor constructor should throw.
+    // the placeholder is for the pipe socket. 
+    BOOST_CHECK_THROW(zmqpp::actor actor(std::bind(&count_echo_server, std::placeholders::_1,
+            &application_context, "InvalidEndpointForRouter")),
+            zmqpp::actor_initialization_exception);
+}
+
+BOOST_AUTO_TEST_CASE(test_actor_stop_failed)
+{
+    // a task that simulates failure to stop
+    auto lambda_fail = [] (zmqpp::socket * pipe) -> bool
+    {
+        pipe->send(zmqpp::signal::ok); // signal start ok
+
+        //wait for stop signal
+        while (true)
+        {
+            if (pipe->wait() == zmqpp::signal::stop)
+                break;
+        }
+        // for some reason let's say we failed to properly stopped the task.
+        return false;
+    };
+
+    // a task that successfully stops
+    auto lambda_success = [] (zmqpp::socket * pipe) -> bool
+    {
+        pipe->send(zmqpp::signal::ok); // signal start ok
+
+        //wait for stop signal
+        while (true)
+        {
+            if (pipe->wait() == zmqpp::signal::stop)
+                break;
+        }
+        return true;
+    };
+
+    zmqpp::actor actor1(lambda_success);
+    zmqpp::actor actor2(lambda_fail);
+    BOOST_CHECK_EQUAL(true, actor1.stop(true));
+    BOOST_CHECK_EQUAL(false, actor2.stop(true));
+}
+
+BOOST_AUTO_TEST_CASE(test_sending_command)
+{
+    zmqpp::context application_context; // what would be the default context we use generally.
+    zmqpp::actor actor(std::bind(&count_echo_server, std::placeholders::_1, &application_context, "inproc://router-endpoint"));
+
+    zmqpp::socket client(application_context, zmqpp::socket_type::dealer);
+    client.connect("inproc://router-endpoint"); // simulate a random client of the router
+
+    int c;
+
+    for (int i = 0; i < 10; i++)
+    {
+        if (i % 3 == 0)
+        {
+            zmqpp::message msg;
+            actor.pipe()->send("GET_COUNT");
+            actor.pipe()->receive(msg);
+            msg >> c;
+            BOOST_CHECK_EQUAL(i, c);
+        }
+        client.send("Hello");
+        std::string bla;
+        client.receive(bla); // we need to receive otherwise the count may be wrong
+    }
+    // assert total count
+    zmqpp::message msg;
+    actor.pipe()->send("GET_COUNT");
+    actor.pipe()->receive(msg);
+    msg >> c;
+    BOOST_CHECK_EQUAL(10, c);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_socket.cpp
+++ b/src/tests/test_socket.cpp
@@ -13,6 +13,7 @@
 #include "zmqpp/context.hpp"
 #include "zmqpp/socket.hpp"
 #include "zmqpp/message.hpp"
+#include "zmqpp/signal.hpp"
 
 BOOST_AUTO_TEST_SUITE( socket )
 
@@ -379,6 +380,53 @@ BOOST_AUTO_TEST_CASE( multitarget_puller )
 	BOOST_CHECK_EQUAL("hello world!", message);
 	BOOST_CHECK(puller.receive(message));
 	BOOST_CHECK_EQUAL("a test message", message);
+}
+
+
+BOOST_AUTO_TEST_CASE( test_receive_send_signals )
+{
+    zmqpp::context ctx;
+    zmqpp::socket p1(ctx, zmqpp::socket_type::pair);
+    zmqpp::socket p2(ctx, zmqpp::socket_type::pair);
+    
+    p1.bind("inproc://test");
+    p2.connect("inproc://test");
+    
+    p1.send(zmqpp::signal::test);
+    p1.send("....");
+    p1.send(zmqpp::signal::stop);
+
+    zmqpp::signal s;
+    std::string str;
+    
+    p2.receive(s);
+    BOOST_CHECK_EQUAL(zmqpp::signal::test, s);
+    p2.receive(str);
+    p2.send(zmqpp::signal::test);
+    p2.receive(s);
+    BOOST_CHECK_EQUAL(zmqpp::signal::stop, s);
+    
+    p1.receive(s);
+    BOOST_CHECK_EQUAL(zmqpp::signal::test, s);
+}
+
+BOOST_AUTO_TEST_CASE( test_wait )
+{
+    zmqpp::context ctx;
+    zmqpp::socket p1(ctx, zmqpp::socket_type::pair);
+    zmqpp::socket p2(ctx, zmqpp::socket_type::pair);
+    
+    p1.bind("inproc://test");
+    p2.connect("inproc://test");
+    
+    p1.send(zmqpp::signal::test);
+    p1.send("....");
+    p1.send("___");
+    p1.send(zmqpp::signal::stop);
+
+    // test wait(): the non signal message must be discarded.
+    BOOST_CHECK_EQUAL(zmqpp::signal::test, p2.wait());
+    BOOST_CHECK_EQUAL(zmqpp::signal::stop, p2.wait());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/zmqpp/actor.cpp
+++ b/src/zmqpp/actor.cpp
@@ -1,0 +1,92 @@
+/* 
+ * File:   actor.cpp
+ * Author: xaqq
+ * 
+ * Created on May 20, 2014, 10:51 PM
+ */
+
+#include "actor.hpp"
+#include "socket.hpp"
+#include <cassert>
+#include "message.hpp"
+#include "exception.hpp"
+#include "context.hpp"
+
+#include <iostream>
+
+zmqpp::context zmqpp::actor::actor_pipe_ctx_;
+
+namespace zmqpp
+{
+
+    actor::actor(ActorStartRoutine routine) :
+    parent_pipe_(nullptr),
+    child_pipe_(nullptr),
+    stopped_(false)
+    {
+        std::string pipe_endpoint = "inproc://zmqpp::actor::" + std::to_string(reinterpret_cast<ptrdiff_t> (this));
+        parent_pipe_ = new socket(actor_pipe_ctx_, socket_type::pair);
+        parent_pipe_->bind(pipe_endpoint);
+
+        child_pipe_ = new socket(actor_pipe_ctx_, socket_type::pair);
+        child_pipe_->connect(pipe_endpoint);
+
+        std::thread t(&actor::start_routine, this, child_pipe_, routine);
+        t.detach();
+
+        signal sig;
+        parent_pipe_->receive(sig);
+        assert(sig == signal::ok || sig == signal::ko);
+        if (sig == signal::ko)
+        {
+            delete parent_pipe_;
+            throw actor_initialization_exception();
+        }
+    }
+
+    actor::~actor()
+    {
+        stop(true);
+        delete parent_pipe_;
+    }
+
+    bool actor::stop(bool block)
+    {
+        parent_pipe_->send(signal::stop, true);
+        if (!block)
+        {
+            return true;
+        }
+        else
+        {
+            if (stopped_)
+                return retval_;
+
+            // wait for a response from the child. Either it successfully shutdown, or not.
+            signal sig = parent_pipe_->wait();
+            stopped_ = true;
+            assert(sig == signal::ok || sig == signal::ko);
+            return (retval_ = (sig == signal::ok));
+        }
+    }
+
+    void actor::start_routine(socket *child_pipe, ActorStartRoutine routine)
+    {
+        if (routine(child_pipe))
+            child_pipe->send(signal::ok);
+        else
+            child_pipe->send(signal::ko);
+        delete child_pipe;
+    }
+
+    socket* actor::pipe()
+    {
+        return parent_pipe_;
+    }
+
+    const socket* actor::pipe() const
+    {
+        return parent_pipe_;
+    }
+
+}

--- a/src/zmqpp/actor.hpp
+++ b/src/zmqpp/actor.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <thread>
+#include <functional>
+#include "socket.hpp"
+
+namespace zmqpp
+{
+
+    /**
+     * An actor is a thread with a pair socket connected to its parent.
+     * It aims to be similar to CMZQ's zactor.
+     * 
+     * From the parent thread, instancing an actor will spawn a new thread, and install
+     * a pipe between those two threads.
+     *	1. The parent's end of the pipe can be retrieved by calling pipe() on the actor.
+     *	2. The child's end is passed as a parameter to the routine executed in the child's thread.
+     * 
+     * You don't have to manage the 2 PAIR sockets. The parent's one will be destroyed
+     * when the actor dies, and the child's end is taken care of when the user routine ends.
+     * 
+     * @note
+     *  About user-supplied routine return value:
+     *	1. If the supplied routine returns true, signal::ok will be send to the parent.
+     *	2. If it returns false, signal::ko is send instead.
+     * 
+     * @note
+     * There is a simple protocol between actor and parent to avoid synchronization problem:
+     *	1. The actor constructor expect to receive either signal::ok or signal::ko before it returns.
+     *	2. When sending signal::stop (actor destruction or by calling stop()), we expect a response:
+     *	    (either signal::ko or signal::ok). This response is used to determine if stop() will return
+     *	    true or false when in blocking mode.
+     */
+    class actor
+    {
+    public:
+	/**
+	 * The user defined function type.
+	 */
+	typedef std::function<bool (socket *pipe) > ActorStartRoutine;
+
+	/**
+	 * Create a new actor. This will effectively create a new thread and runs the user supplied routine.
+	 * The constructor expect a signal from the routine before returning.
+	 * 
+	 * Expect to receive either signal::ko or signal::ok before returning.
+	 * If it receives signal::ko, it will throw. 
+	 * @param routine to be executed.
+	 */
+	actor(ActorStartRoutine routine);
+	actor(const actor&) = delete;
+	virtual ~actor();
+
+	/**
+	 * @return pointer to the parent's end of the pipe
+	 */
+	socket *pipe();
+
+	/**
+	 * @return const pointer to the parent's end of the pipe
+	 */
+	const socket *pipe() const;
+
+	/**
+	 * Sends signal::stop to the actor thread.
+	 * The actor thread shall stop as soon as possible.
+	 * The return value is only relevant when block is true. If block is false (the default), this method
+	 * will return true.
+	 * 
+	 * It is safe to call stop() multiple time (to ask the actor to shutdown, and then a bit
+	 * later call stop(true) to make sure it is really stopped)
+	 * 
+	 * @param block whether or not we wait until the actor thread stops.
+	 * @return a boolean indicating whether or not the actor successfully shutdown.
+	 */
+	bool stop(bool block = false);
+
+    private:
+	/**
+	 * Call a user defined function and performs cleanup once it returns.
+	 * We use a copy of child_pipe_ here; this is to avoid a race condition where the
+	 * destructor would be called before start_routine finishes but after it sent signal::ok / signal::ko.
+	 * The actor object would be invalid (because already destroyed).
+	 * 
+	 * @param child a copy of child_pipe_.
+	 * @param routine user routine that will be called
+	 */
+	void start_routine(socket *child, ActorStartRoutine routine);
+
+	/**
+	 * The parent thread socket.
+	 * This socket will be closed and freed by the actor destructor.
+	 */
+	socket *parent_pipe_;
+
+	/**
+	 * The child end of the pipe.
+	 * It is closed and freed when the routine ran by the actor ends.
+	 */
+	socket *child_pipe_;
+
+	/**
+	 * This static, per process zmqpp::context, is used to connect PAIR socket
+	 * between Actor and their parent thread.
+	 */
+	static context actor_pipe_ctx_;
+
+	/**
+	 * Keeps track of the status of the actor thread.
+	 */
+	bool stopped_;
+
+	bool retval_;
+    };
+}

--- a/src/zmqpp/exception.hpp
+++ b/src/zmqpp/exception.hpp
@@ -54,6 +54,20 @@ public:
 	{ }
 };
 
+    /**
+     * Represents a failed zmqpp::actor initialization.
+     */
+    class actor_initialization_exception : public exception
+    {
+    public:
+
+	actor_initialization_exception() :
+	exception("Actor Initialization Exception")
+	{
+	}
+
+    };
+
 /*!
  * Represents internal zmq errors.
  *

--- a/src/zmqpp/message.cpp
+++ b/src/zmqpp/message.cpp
@@ -141,6 +141,15 @@ void message::get(int64_t& integer, size_t const part) const
 	integer = static_cast<int64_t>(zmqpp::htonll(*network_order));
 }
 
+void message::get(signal &sig, size_t const part) const
+{
+    assert(sizeof(signal) == size(part));
+    int64_t v;
+    get(v, part);
+    
+    sig = static_cast<signal>(v);
+}
+
 void message::get(uint8_t& unsigned_integer, size_t const part) const
 {
 	assert(sizeof(uint8_t) == size(part));
@@ -234,6 +243,10 @@ message& message::operator<<(int64_t const integer)
 	return *this;
 }
 
+message &message::operator<<(signal const sig)
+{
+    return (*this) << static_cast<int64_t>(sig);
+}
 
 message& message::operator<<(uint8_t const unsigned_integer)
 {
@@ -333,6 +346,10 @@ void message::push_front(int64_t const integer)
 	push_front(&network_order, sizeof(uint64_t));
 }
 
+void message::push_front(signal const sig)
+{
+    push_front(static_cast<int64_t>(sig));
+}
 
 void message::push_front(uint8_t const unsigned_integer)
 {
@@ -449,6 +466,18 @@ void message::release_callback(void* data, void* hint)
 	releaser->func(data);
 
 	delete releaser;
+}
+
+bool message::is_signal() const
+{
+    if (parts() == 1 && size(0) == sizeof(signal))
+    {
+        signal s;
+        get(s, 0);
+        if ((static_cast<int64_t>(s) >> 8) == static_cast<int64_t>(signal::header))
+            return true;
+    }
+    return false;
 }
 
 }

--- a/src/zmqpp/message.hpp
+++ b/src/zmqpp/message.hpp
@@ -18,6 +18,7 @@
 
 #include "compatibility.hpp"
 #include "frame.hpp"
+#include "signal.hpp"
 
 namespace zmqpp
 {
@@ -61,7 +62,8 @@ public:
 	void get(int8_t& integer, size_t const part) const;
 	void get(int16_t& integer, size_t const part) const;
 	void get(int32_t& integer, size_t const part) const;
-	void get(int64_t& integer, size_t const part) const;
+	void get(int64_t& integer, size_t const part) const;	
+	void get(signal& sig, size_t const part) const;
 
 	void get(uint8_t& unsigned_integer, size_t const part) const;
 	void get(uint16_t& unsigned_integer, size_t const part) const;
@@ -162,6 +164,7 @@ public:
 	message& operator<<(int16_t const integer);
 	message& operator<<(int32_t const integer);
 	message& operator<<(int64_t const integer);
+	message& operator<<(signal const sig);
 
 	message& operator<<(uint8_t const unsigned_integer);
 	message& operator<<(uint16_t const unsigned_integer);
@@ -183,6 +186,7 @@ public:
 	void push_front(int16_t const integer);
 	void push_front(int32_t const integer);
 	void push_front(int64_t const integer);
+	void push_front(signal const sig);
 
 	void push_front(uint8_t const unsigned_integer);
 	void push_front(uint16_t const unsigned_integer);
@@ -229,6 +233,14 @@ public:
 	zmq_msg_t& raw_msg(size_t const part = 0);
 	zmq_msg_t& raw_new_msg();
 	zmq_msg_t& raw_new_msg(size_t const reserve_data_size);
+	
+	/**
+	 * Check if the message is a signal.
+	 * If the message has 1 part, has the correct size and if the 7 first bytes match
+	 * the signal header we consider the message a signal.
+	 * @return true if the message is a signal, false otherwise
+	 */
+	bool is_signal() const;
 
 private:
 	typedef std::vector<frame> parts_type;

--- a/src/zmqpp/signal.cpp
+++ b/src/zmqpp/signal.cpp
@@ -1,0 +1,11 @@
+#include "signal.hpp"
+
+namespace std
+{
+
+    ostream &operator<<(ostream &s, const zmqpp::signal &sig)
+    {
+        s << static_cast<int64_t> (sig);
+        return s;
+    }
+}

--- a/src/zmqpp/signal.hpp
+++ b/src/zmqpp/signal.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+#include <iostream>
+
+namespace zmqpp
+{
+
+    /**
+     * Signal is a 8 bytes integer. 7 first bytes acts as a magic number so we can distinguish signal
+     * from other message. The last byte is the signal's value.
+     */
+    enum class signal : int64_t
+    {
+	/**
+	 * Only 7 bytes matter here
+	 */
+	header = 0x0077665544332211L,
+	/**
+	 * Indicates a success.
+	 */
+	ok = (header << 8) | 0x00,
+	/**
+	 * Indicates an error.
+	 */
+	ko = (header << 8) | 0x01,
+	/**
+	 * Indicates a request to stop. This is used from parent thread to child within the actor class
+	 */
+	stop = (header << 8) | 0x02,
+
+	test = (header << 8) | 0xFF
+    };
+
+}
+
+
+namespace std
+{
+    /**
+     * Write the value of the signal to the stream without removing the signal header..
+     */
+    ostream &operator<<(ostream &s, const zmqpp::signal &sig);
+}

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -114,6 +114,24 @@ void socket::close()
 	_socket = nullptr;
 }
 
+bool socket::send(zmqpp::signal sig, int const flags)
+{
+    message msg(sig);
+    return send(msg, flags);
+}
+
+bool socket::receive(zmqpp::signal &sig, int const flags)
+{
+    message msg;
+    bool ret = receive(msg, normal);
+    if (ret)
+    {
+        assert(msg.is_signal());
+        msg.get(sig, 0);
+    }
+    return ret;
+}
+
 bool socket::send(message& message, bool const dont_block /* = false */)
 {
 	size_t parts = message.parts();
@@ -753,6 +771,23 @@ void socket::track_message(message const& /* message */, uint32_t const parts, b
 	{
 		should_delete = true;
 	}
+}
+
+
+signal socket::wait()
+{
+    while (true)
+    {
+        message msg;
+        receive(msg);
+        
+        if (msg.is_signal())
+        {
+            signal sig;
+            msg.get(sig, 0);
+            return sig;
+        }
+    }
 }
 
 }

--- a/src/zmqpp/socket.hpp
+++ b/src/zmqpp/socket.hpp
@@ -18,6 +18,7 @@
 
 #include "socket_types.hpp"
 #include "socket_options.hpp"
+#include "signal.hpp"
 
 namespace zmqpp
 {
@@ -203,7 +204,31 @@ public:
 	 * \return true if message part received, false if it would have blocked
 	 */
 	bool receive(std::string& string, int const flags = normal);
+	
+	/**
+	 * Sends a signal over the socket.
+	 * 
+	 * If the socket::DONT_WAIT flag and we are unable to add a new message to
+	 * socket then this function will return false.
+	 * @param sig signal to send.
+	 * @param flags message send flags
+	 * @return true if message part sent, false if it would have blocked
+	 */
+	bool send(signal sig, int const flags = normal);
 
+
+    	/*!
+	 * If there is a message ready then we read a signal from it.
+	 *
+	 * If the socket::DONT_WAIT flag and there is no message ready to receive
+	 * then this function will return false.
+	 *
+	 * \param sig signal to receive into
+	 * \param flags message receive flags
+	 * \return true if signal received, false if it would have blocked
+	 */
+	bool receive(signal &sig, int const flags = normal);
+	
 	/*!
 	 * Sends the byte data pointed to by buffer as the next part of the message.
 	 *
@@ -440,6 +465,15 @@ public:
 		return value;
 	}
 
+	/**
+	 * Wait on signal, this is useful to coordinate thread.
+	 * Block until a signal is received, and returns the received signal.
+	 * 
+	 * Discard everything until something that looks like a signal is received.
+	 * @return the signal.
+	 */
+	signal wait();
+	
 	/*!
 	 * Move constructor
 	 *


### PR DESCRIPTION
This is a PR following up the discussion in #50 about zthread/zactor.

This PR adds the following:
1. A `zmqpp::actor` class, that aims to be similar to CZMQ zactor.
2. A `zmqpp::signal` enumeration that regroup different signal code.
3. `zmqpp::socket` and `zmqpp::message` have new methods to deal with `zmqpp::signal`.

There is however a few differences between `zmqpp::actor` and zactor:
1. The user-defined routine that runs in actor thread can notify its parent it failed to initialize, thus causing the actor constructor to throw.
2. The actor is allowed to fail its shutdown process. There is no difference between a failed shutdown (ie the thread must stop anyway), but the state of the shutdown can be retrieved by the parent (using a blocking call to `stop()`.
