### PR TITLE
Enable unbind and disconnect methods for class socket only for ZMQ >= 3.2

### DIFF
--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -72,6 +72,7 @@ void socket::bind(endpoint_t const& endpoint)
 	}
 }
 
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 void socket::unbind(endpoint_t const& endpoint)
 {
 	int result = zmq_unbind(_socket, endpoint.c_str());
@@ -81,6 +82,7 @@ void socket::unbind(endpoint_t const& endpoint)
 		throw zmq_internal_exception();
 	}
 }
+#endif
 
 void socket::connect(endpoint_t const& endpoint)
 {
@@ -92,6 +94,7 @@ void socket::connect(endpoint_t const& endpoint)
 	}
 }
 
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 void socket::disconnect(endpoint_t const& endpoint)
 {
 	int result = zmq_disconnect(_socket, endpoint.c_str());
@@ -101,6 +104,7 @@ void socket::disconnect(endpoint_t const& endpoint)
 		throw zmq_internal_exception();
 	}
 }
+#endif
 
 void socket::close()
 {

--- a/src/zmqpp/socket.hpp
+++ b/src/zmqpp/socket.hpp
@@ -85,12 +85,14 @@ public:
 	 */
 	void bind(endpoint_t const& endpoint);
 
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 	/*!
 	 * Unbinds from a previously bound endpoint.
 	 *
 	 * \param endpoint the zmq endpoint to bind to
 	 */
 	void unbind(endpoint_t const& endpoint);
+#endif
 
 	/*!
 	 * Asynchronously connects to an endpoint.
@@ -132,6 +134,7 @@ public:
 	 *
 	 * \param endpoint the zmq endpoint to disconnect from
 	 */
+#if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 	void disconnect(endpoint_t const& endpoint);
 
 	/*!
@@ -150,6 +153,7 @@ public:
 			disconnect(*it);
 		}
 	}
+#endif
 
 	/*!
 	 * Closes the internal zmq socket and marks this instance


### PR DESCRIPTION
Unfortunately I have to use ZMQ2.2 with my applications and the recent addition in 165e93 broke my compilation.

I'm not sure about the ifdef conditions.
