### PR TITLE
Revert "Flags are ignored on signal receive overload."

### DIFF
--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -127,7 +127,7 @@ bool socket::send(zmqpp::signal sig, int const flags)
 bool socket::receive(zmqpp::signal &sig, int const flags)
 {
     message msg;
-    bool ret = receive(msg, flags);
+    bool ret = receive(msg, normal);
     if (ret)
     {
         assert(msg.is_signal());


### PR DESCRIPTION
Sorry I thought it is a typo, but I have made it worse. Flags is implicitly casted to bool and now this overload is always dont_block. Maybe all send and receive methods should be more consistent, expecting only bools or only flags?
