### PR TITLE
Fix compilation with gcc < 4.4

### DIFF
--- a/src/zmqpp/context_options.hpp
+++ b/src/zmqpp/context_options.hpp
@@ -16,7 +16,7 @@ namespace zmqpp
  * \brief possible Context options in zmq
  */
 
-enum class context_option {
+ZMQPP_COMPARABLE_ENUM context_option {
 	io_threads  = ZMQ_IO_THREADS,          /*!< I/O thread count */
 	max_sockets = ZMQ_MAX_SOCKETS,         /*!< Maximum supported sockets */
 #if (ZMQ_VERSION_MAJOR >= 4)

--- a/src/zmqpp/signal.hpp
+++ b/src/zmqpp/signal.hpp
@@ -10,7 +10,7 @@ namespace zmqpp
      * Signal is a 8 bytes integer. 7 first bytes acts as a magic number so we can distinguish signal
      * from other message. The last byte is the signal's value.
      */
-    enum class signal : int64_t
+    ZMQPP_COMPARABLE_ENUM signal : int64_t
     {
 	/**
 	 * Only 7 bytes matter here

--- a/src/zmqpp/socket_mechanisms.hpp
+++ b/src/zmqpp/socket_mechanisms.hpp
@@ -16,7 +16,7 @@ namespace zmqpp
  *
  * Each is designed for a different use and has different limitations.
  */
-enum class socket_security {
+ZMQPP_COMPARABLE_ENUM socket_security {
 #if (ZMQ_VERSION_MAJOR >= 4)
 	/*!
 	 * The NULL mechanism is defined by the ZMTP 3.0 specification:

--- a/src/zmqpp/socket_options.hpp
+++ b/src/zmqpp/socket_options.hpp
@@ -16,7 +16,7 @@ namespace zmqpp
  * \brief possible Socket options in zmq
  */
 
-enum class socket_option {
+ZMQPP_COMPARABLE_ENUM socket_option {
 	affinity                  = ZMQ_AFFINITY,          /*!< I/O thread affinity */
 	identity                  = ZMQ_IDENTITY,          /*!< Socket identity */
 	subscribe                 = ZMQ_SUBSCRIBE,         /*!< Add topic subscription - set only */

--- a/src/zmqpp/socket_types.hpp
+++ b/src/zmqpp/socket_types.hpp
@@ -18,7 +18,7 @@ namespace zmqpp
  *
  * Each is designed for a different use and has different limitations.
  */
-enum class socket_type {
+ZMQPP_COMPARABLE_ENUM socket_type {
 	/*!
 	 * One to one - two way connection.\n
 	 * Connect to ::pair.\n


### PR DESCRIPTION
Older version of gcc does not support "enum class" declaration. However,
there is already a macro to fix this compatibility issue:
ZMQPP_COMPARABLE_ENUM. This patch use this macro instead of "enum class"
