### PR TITLE
Fix the build error created by #64 because of a missing header inclusion

### DIFF
--- a/src/zmqpp/signal.hpp
+++ b/src/zmqpp/signal.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include "compatibility.hpp"
 
 namespace zmqpp
 {


### PR DESCRIPTION
A missing header inclusion cause the build to fail. This fixes it.
