### PR TITLE
Add move semantic to zmqpp::actor

### DIFF
--- a/src/tests/test_actor.cpp
+++ b/src/tests/test_actor.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(test_actor_movable)
         pipe->send("boap1");
         pipe->send("boap2");
         pipe->send("boap3");
-        return true; // will send signal::ok to signal successful shutdown
+        return true;
     };
     zmqpp::actor actor1(lambda);
 
@@ -63,6 +63,10 @@ BOOST_AUTO_TEST_CASE(test_actor_movable)
     zmqpp::actor actor3(std::move(actor2));
     actor3.pipe()->receive(str);
     BOOST_CHECK_EQUAL("boap3", str);
+    BOOST_CHECK_EQUAL(actor3.stop(true), true);
+
+    zmqpp::actor actor4(std::move(actor3));
+    BOOST_CHECK_EQUAL(actor4.stop(true), true);
 }
 
 BOOST_AUTO_TEST_CASE(child_thread_wait_for_stop)

--- a/src/zmqpp/actor.cpp
+++ b/src/zmqpp/actor.cpp
@@ -65,7 +65,7 @@ namespace zmqpp
         delete parent_pipe_;
     }
 
-    bool actor::stop(bool block)
+    bool actor::stop(bool block /* = false */)
     {
         if (!parent_pipe_)
 	  return false;

--- a/src/zmqpp/actor.hpp
+++ b/src/zmqpp/actor.hpp
@@ -83,8 +83,8 @@ namespace zmqpp
 	 * It is safe to call stop() multiple time (to ask the actor to shutdown, and then a bit
 	 * later call stop(true) to make sure it is really stopped)
 	 * 
-	 * @note calling this method on a "moved" actor will return false and no action
-	 * will be taken.
+	 * @note calling this method on an "empty" actor (after it was moved) will return
+	 * false and nothing will happen.
 	 * @param block whether or not we wait until the actor thread stops.
 	 * @return a boolean indicating whether or not the actor successfully shutdown.
 	 */

--- a/src/zmqpp/zmqpp.hpp
+++ b/src/zmqpp/zmqpp.hpp
@@ -55,6 +55,8 @@
 #include "message.hpp"
 #include "poller.hpp"
 #include "socket.hpp"
+#include "actor.hpp"
+#include "reactor.hpp"
 
 /*!
  * \brief C++ wrapper around zmq


### PR DESCRIPTION
This PR adds move semantic to the `zmqpp::actor` class by adding a move-constructor and a move-assignment operator.

It also adds the actor and reactor includes files to `zmqpp.hpp`.
