### PR TITLE
Added CMakeLists.txt to use with CMake builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set( IS_TRAVIS_CI_BUILD   true    CACHE bool "Defines TRAVIS_CI_BUILD - Should t
 
 # Find zmq.h and add its dir to the includes
 find_path(ZEROMQ_INCLUDE zmq.h PATHS ${ZEROMQ_INCLUDE_DIR})
-include_directories(${ZEROMQ_INCLUDE})
+include_directories(${ZEROMQ_INCLUDE} ${CMAKE_CURRENT_SOURCE_DIR}/src )
 
 # Do not run some tests when building on travis-ci (this cause oom error and kill the test
 # process)


### PR DESCRIPTION
This has been so far only tested on OSX 10.9 with Clang.
- ZMQ's current CMakeLists.txt build messes up **MACOSX_RPATH** and cannot build the shared library, so this CMakeLists.txt tries to compensate for that by allowing to link the shared ZMQPP library with the static ZMQ lib. So far it seems to work for me, but it needs to be tested.
- **IS_TRAVIS_CI_BUILD**  is On by default, because _sending_large_messages_string_ test takes too long to comfortably use ctest.
- Since the client has bugs (typos) and wont compile, its disabled by default.
- Generally, ZMQPP is used as a lib for other projects, so it makes sense to turn off building the tests by default. Need more feedback on this.
