### PR TITLE
Few code cleanup / fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,5 @@ before_script:
 script:
   - make CXXFLAGS='-DTRAVIS_CI_BUILD' check
   - make clean ; make CUSTOM_INCLUDE_PATH='-I/tmp/ZMQ3/include' COMMON_LIBS='-L/tmp/ZMQ3/lib/ -lzmq' check
+  ## now try to build using cmake just as a sanity check
+  - rm -rf build && mkdir build && cd build && cmake ../ -DZMQPP_BUILD_STATIC=0 -DZMQPP_BUILD_TESTS=1 && make && ./zmqpp-test-runner;

--- a/src/tests/test_sanity.cpp
+++ b/src/tests/test_sanity.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE( zmq_basic_push_pull )
 	BOOST_CHECK_EQUAL(data.size(), zmq_send(pusher, data.data(), data.size(), 0));
 #endif
 
-	zmq_pollitem_t items[] = { { puller, ZMQ_POLLIN, 0 } };
+	zmq_pollitem_t items[] = { { puller, ZMQ_POLLIN, 0, 0 } };
 	BOOST_CHECK_EQUAL(0, zmq_poll(items, 1, max_poll_timeout));
 
 	zmq_msg_t received_message;

--- a/src/zmqpp/actor.hpp
+++ b/src/zmqpp/actor.hpp
@@ -102,6 +102,13 @@ namespace zmqpp
 	 */
 	void start_routine(socket *child, ActorStartRoutine routine);
 
+         /**
+         * Bind the parent socket and return the endpoint used.
+         * Since endpoint are generated and have to be tested for availability
+         * this method is reponsible for finding a valid endpoint to bind to.
+         */
+	 std::string bind_parent();
+
 	/**
 	 * The parent thread socket.
 	 * This socket will be closed and freed by the actor destructor.

--- a/src/zmqpp/message.hpp
+++ b/src/zmqpp/message.hpp
@@ -145,18 +145,18 @@ public:
 
 	// Copy operators will take copies of any data with a given size
 	template<typename Type>
-	void add_raw(Type *part, size_t const size)
+	void add_raw(Type *part, size_t const data_size)
 	{
-		_parts.push_back( frame( part, size ) );
+		_parts.push_back( frame( part, data_size ) );
 	}
 
 	// Use exact data past, neither zmqpp nor 0mq will copy, alter or delete
 	// this data. It must remain as valid for at least the lifetime of the
 	// 0mq message, recommended only with const data.
 	template<typename Type>
-	void add_const(Type *part, size_t const size)
+	void add_const(Type *part, size_t const data_size)
 	{
-		_parts.push_back( frame( part, size, nullptr, nullptr ) );
+		_parts.push_back( frame( part, data_size, nullptr, nullptr ) );
 	}
 
 	// Stream reader style
@@ -212,9 +212,9 @@ public:
 
 	void pop_front();
 
-	void push_back(void const* part, size_t const size)
+	void push_back(void const* part, size_t const data_size)
 	{
-		add_raw( part, size );
+		add_raw( part, data_size );
 	}
 
 	template<typename Type>

--- a/src/zmqpp/z85.hpp
+++ b/src/zmqpp/z85.hpp
@@ -31,7 +31,7 @@ namespace zmqpp
      * @return a vector of uint8_t: the binary block after string decoding.
      */
     std::vector<uint8_t> decode(const std::string &string);
-  };
+  }
 #endif
 
-};
+}


### PR DESCRIPTION
This PR changes the following:
- Travis should build with cmake too, just as a sanity check
- Fixes a 'missing initializer' warning.
- Change the inproc:// endpoint for actor so it cannot conflict anymore.
- pedantic warning in z85.hpp
- Prevent shadowing warning when compiling with certain flags
