### PR TITLE
Expose the read_cursor for zmqpp::message.

### DIFF
--- a/src/zmqpp/message.hpp
+++ b/src/zmqpp/message.hpp
@@ -252,6 +252,21 @@ public:
 	 */
 	bool is_signal() const;
 
+	/**
+	 * Gets the read cursor. For using get_raw() with stream-style reading.
+	 */
+	size_t read_cursor() const NOEXCEPT { return _read_cursor; }
+
+	/**
+	 * Gets the remaining number of parts in the message.
+	 */
+	size_t remaining() const NOEXCEPT { return  _parts.size() - _read_cursor; }
+
+	/**
+	 * Moves the read cursor to the next element.
+	 * @return the new read_cursor
+	 */
+	size_t next() NOEXCEPT { return ++_read_cursor; }
 private:
 	typedef std::vector<frame> parts_type;
 	parts_type _parts;


### PR DESCRIPTION
Just something I needed to work quickly (no tests :/ ). This enables to use the stream-style reader interface with get_raw().
- This may not be the best idea, perheaps exposing the underlying zmqpp::frame in the stream interface would be better.
- Or perheaps refactoring the whole stream interface to its separate class.

To be used for code something like this:

``` c++
  message& operator>>(message& msg, EventBlock& evt)
  {
    // if there are no more parts in the message, return an empty memory block
    if (msg.remaining() < 3) {
      evt = EventBlock();
      return msg;
    }
    uint64_t category, source_id;
    MemoryBlock data;
    msg >> category >> source_id >> data;
    evt = EventBlock(category, source_id, std::move(data));
    return msg;
  }

  message& operator>>(message& msg, MemoryBlock& mb)
  {
    // if there are no more parts in the message, return an empty memory block
    if (msg.remaining() == 0) {
      mb = MemoryBlock();
      return msg;
    }
    // the data is stored as a frame
    const auto cursor = msg.read_cursor();
    mb = MemoryBlock(msg.raw_data(cursor), msg.size(cursor));
    msg.next();
    return msg;
  }
```
