### PR TITLE
Rename htonll/ntohll so zmqpp can build in Yosemite.

### DIFF
--- a/src/zmqpp/inet.hpp
+++ b/src/zmqpp/inet.hpp
@@ -76,7 +76,7 @@ inline uint64_t swap_if_needed(uint64_t const value_to_check)
  * \param hostlonglong unsigned 64 bit host order integer
  * \return unsigned 64 bit network order integer
  */
-inline uint64_t htonll(uint64_t const hostlonglong)
+inline uint64_t zmqpp_htonll(uint64_t const hostlonglong)
 {
 	return zmqpp::swap_if_needed(hostlonglong);
 }
@@ -89,7 +89,7 @@ inline uint64_t htonll(uint64_t const hostlonglong)
  * \param networklonglong unsigned 64 bit network order integer
  * \return unsigned 64 bit host order integer
  */
-inline uint64_t ntohll(uint64_t const networklonglong)
+inline uint64_t zmqpp_ntohll(uint64_t const networklonglong)
 {
 	return zmqpp::swap_if_needed(networklonglong);
 }
@@ -142,7 +142,7 @@ inline double htond(double value)
 
 	uint64_t temp;
 	memcpy(&temp, &value, sizeof(uint64_t));
-	temp = zmqpp::htonll(temp);
+	temp = zmqpp::zmqpp_htonll(temp);
 	memcpy(&value, &temp, sizeof(uint64_t));
 
 	return value;
@@ -160,7 +160,7 @@ inline double ntohd(double value)
 
 	uint64_t temp;
 	memcpy(&temp, &value, sizeof(uint64_t));
-	temp = zmqpp::ntohll(temp);
+	temp = zmqpp::zmqpp_ntohll(temp);
 	memcpy(&value, &temp, sizeof(uint64_t));
 
 	return value;

--- a/src/zmqpp/message.cpp
+++ b/src/zmqpp/message.cpp
@@ -138,7 +138,7 @@ void message::get(int64_t& integer, size_t const part) const
 	assert(sizeof(int64_t) == size(part));
 
 	uint64_t const* network_order = static_cast<uint64_t const*>(raw_data(part));
-	integer = static_cast<int64_t>(zmqpp::htonll(*network_order));
+	integer = static_cast<int64_t>(zmqpp::zmqpp_htonll(*network_order));
 }
 
 void message::get(signal &sig, size_t const part) const
@@ -179,7 +179,7 @@ void message::get(uint64_t& unsigned_integer, size_t const part) const
 	assert(sizeof(uint64_t) == size(part));
 
 	uint64_t const* network_order = static_cast<uint64_t const*>(raw_data(part));
-	unsigned_integer = zmqpp::ntohll(*network_order);
+	unsigned_integer = zmqpp::zmqpp_ntohll(*network_order);
 }
 
 void message::get(float& floating_point, size_t const part) const
@@ -237,7 +237,7 @@ message& message::operator<<(int32_t const integer)
 
 message& message::operator<<(int64_t const integer)
 {
-	uint64_t network_order = zmqpp::htonll(static_cast<uint64_t>(integer));
+	uint64_t network_order = zmqpp::zmqpp_htonll(static_cast<uint64_t>(integer));
 	add_raw(reinterpret_cast<void const*>(&network_order), sizeof(uint64_t));
 
 	return *this;
@@ -272,7 +272,7 @@ message& message::operator<<(uint32_t const unsigned_integer)
 
 message& message::operator<<(uint64_t const unsigned_integer)
 {
-	uint64_t network_order = zmqpp::htonll(unsigned_integer);
+	uint64_t network_order = zmqpp::zmqpp_htonll(unsigned_integer);
 	add_raw(reinterpret_cast<void const*>(&network_order), sizeof(uint64_t));
 
 	return *this;
@@ -342,7 +342,7 @@ void message::push_front(int32_t const integer)
 
 void message::push_front(int64_t const integer)
 {
-	uint64_t network_order = zmqpp::htonll(static_cast<uint64_t>(integer));
+	uint64_t network_order = zmqpp::zmqpp_htonll(static_cast<uint64_t>(integer));
 	push_front(&network_order, sizeof(uint64_t));
 }
 
@@ -370,7 +370,7 @@ void message::push_front(uint32_t const unsigned_integer)
 
 void message::push_front(uint64_t const unsigned_integer)
 {
-	uint64_t network_order = zmqpp::htonll(unsigned_integer);
+	uint64_t network_order = zmqpp::zmqpp_htonll(unsigned_integer);
 	push_front(&network_order, sizeof(uint64_t));
 }
 


### PR DESCRIPTION
Renamed the htonll and ntohll functions because of build errors when running make. Yosemite includes its own 'htonll' and 'ntohll' functions that clash; this fix simply renames the zmqpp-defined functions.

Another workaround would be to implement a guard checking if these functions are already defined.

In file included from /Users/crh/tmp/zmqpp/src/zmqpp/message.cpp:10:
/Users/crh/tmp/zmqpp/src/zmqpp/inet.hpp:79:17: error: expected ')'
inline uint64_t htonll(uint64_t const hostlonglong)
                ^
/usr/include/sys/_endian.h:141:25: note: expanded from macro 'htonll'
# define htonll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:30: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
                             ^
/Users/crh/tmp/zmqpp/src/zmqpp/inet.hpp:79:17: note: to match this '('
/usr/include/sys/_endian.h:141:25: note: expanded from macro 'htonll'
# define htonll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:5: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
    ^
In file included from /Users/crh/tmp/zmqpp/src/zmqpp/message.cpp:10:
/Users/crh/tmp/zmqpp/src/zmqpp/inet.hpp:92:17: error: expected ')'
inline uint64_t ntohll(uint64_t const networklonglong)
                ^
/usr/include/sys/_endian.h:140:25: note: expanded from macro 'ntohll'
# define ntohll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:30: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
                             ^
/Users/crh/tmp/zmqpp/src/zmqpp/inet.hpp:92:17: note: to match this '('
/usr/include/sys/_endian.h:140:25: note: expanded from macro 'ntohll'
# define ntohll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:5: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
    ^
In file included from /Users/crh/tmp/zmqpp/src/zmqpp/message.cpp:10:
/Users/crh/tmp/zmqpp/src/zmqpp/inet.hpp:92:17: error: redefinition of '__builtin_constant_p'
inline uint64_t ntohll(uint64_t const networklonglong)
                ^
/usr/include/sys/_endian.h:140:25: note: expanded from macro 'ntohll'
# define ntohll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:6: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
     ^
/Users/crh/tmp/zmqpp/src/zmqpp/inet.hpp:79:17: note: previous definition is here
inline uint64_t htonll(uint64_t const hostlonglong)
                ^
/usr/include/sys/_endian.h:141:25: note: expanded from macro 'htonll'
# define htonll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:6: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
     ^
In file included from /Users/crh/tmp/zmqpp/src/zmqpp/message.cpp:10:
/Users/crh/tmp/zmqpp/src/zmqpp/inet.hpp:145:16: error: unexpected parenthesis after '::'
        temp = zmqpp::htonll(temp);
                      ^
/usr/include/sys/_endian.h:141:25: note: expanded from macro 'htonll'
# define htonll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:5: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
    ^
In file included from /Users/crh/tmp/zmqpp/src/zmqpp/message.cpp:10:
/Users/crh/tmp/zmqpp/src/zmqpp/inet.hpp:163:16: error: unexpected parenthesis after '::'
        temp = zmqpp::ntohll(temp);
                      ^
/usr/include/sys/_endian.h:140:25: note: expanded from macro 'ntohll'
# define ntohll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:5: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
    ^
/Users/crh/tmp/zmqpp/src/zmqpp/message.cpp:141:40: error: unexpected parenthesis after '::'
        integer = static_cast<int64_t>(zmqpp::htonll(*network_order));
                                              ^
/usr/include/sys/_endian.h:141:25: note: expanded from macro 'htonll'
# define htonll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:5: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
    ^
/Users/crh/tmp/zmqpp/src/zmqpp/message.cpp:182:28: error: unexpected parenthesis after '::'
        unsigned_integer = zmqpp::ntohll(*network_order);
                                  ^
/usr/include/sys/_endian.h:140:25: note: expanded from macro 'ntohll'
# define ntohll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:5: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
    ^
/Users/crh/tmp/zmqpp/src/zmqpp/message.cpp:240:34: error: unexpected parenthesis after '::'
        uint64_t network_order = zmqpp::htonll(static_cast<uint64_t>(integer));
                                        ^
/usr/include/sys/_endian.h:141:25: note: expanded from macro 'htonll'
# define htonll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:5: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
    ^
/Users/crh/tmp/zmqpp/src/zmqpp/message.cpp:275:34: error: unexpected parenthesis after '::'
        uint64_t network_order = zmqpp::htonll(unsigned_integer);
                                        ^
/usr/include/sys/_endian.h:141:25: note: expanded from macro 'htonll'
# define htonll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:5: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
    ^
/Users/crh/tmp/zmqpp/src/zmqpp/message.cpp:345:34: error: unexpected parenthesis after '::'
        uint64_t network_order = zmqpp::htonll(static_cast<uint64_t>(integer));
                                        ^
/usr/include/sys/_endian.h:141:25: note: expanded from macro 'htonll'
# define htonll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:5: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
    ^
/Users/crh/tmp/zmqpp/src/zmqpp/message.cpp:373:34: error: unexpected parenthesis after '::'
        uint64_t network_order = zmqpp::htonll(unsigned_integer);
                                        ^
/usr/include/sys/_endian.h:141:25: note: expanded from macro 'htonll'
# define htonll(x)       __DARWIN_OSSwapInt64(x)

```
                    ^
```

/usr/include/libkern/_OSByteOrder.h:78:5: note: expanded from macro '__DARWIN_OSSwapInt64'
    (__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt64(x) : _OSSwapInt64(x))
    ^
11 errors generated.
