### PR TITLE
Prevent use of uninitialized variable.

### DIFF
--- a/src/zmqpp/actor.cpp
+++ b/src/zmqpp/actor.cpp
@@ -37,7 +37,7 @@ namespace zmqpp
         t.detach();
 
         signal sig;
-        parent_pipe_->receive(sig);
+        sig = parent_pipe_->wait();
         assert(sig == signal::ok || sig == signal::ko);
         if (sig == signal::ko)
         {

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -839,7 +839,7 @@ signal socket::wait()
     while (true)
     {
         message msg;
-        receive(msg);
+        while(!receive(msg));
 
         if (msg.is_signal())
         {


### PR DESCRIPTION
Problem: `wait()` wasn't safe: if `receive()` failed,
if would use an unitialized message.
Solution: Make sure received didnt fail.

Problem: If `receive()` was interrupt (EINTR) actor
constructor would use a non-initialized signal, causing the
assertion to fire.
Solution: Replace call to `receive()` by `wait()` in actor constructor.
