### PR TITLE
Fix build in some rare case.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
   # Requirements
-  - sudo apt-get install libboost-all-dev
+  - sudo apt-get install -qq libboost-all-dev
 
 before_script:
   # Build, check, and install libsodium

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ set( IS_TRAVIS_CI_BUILD   true    CACHE bool "Defines TRAVIS_CI_BUILD - Should t
 
 # Find zmq.h and add its dir to the includes
 find_path(ZEROMQ_INCLUDE zmq.h PATHS ${ZEROMQ_INCLUDE_DIR})
-include_directories(${ZEROMQ_INCLUDE} ${CMAKE_CURRENT_SOURCE_DIR}/src )
+include_directories(${ZEROMQ_INCLUDE_DIR} ${ZEROMQ_INCLUDE} ${CMAKE_CURRENT_SOURCE_DIR}/src )
 
 # Do not run some tests when building on travis-ci (this cause oom error and kill the test
 # process)

--- a/src/zmqpp/curve.hpp
+++ b/src/zmqpp/curve.hpp
@@ -9,6 +9,7 @@
 #define ZMQPP_CURVE_HPP_
 
 #include <string>
+#include <zmq.h>
 
 namespace zmqpp { namespace curve
 {


### PR DESCRIPTION
Problem: My previous update to CMake was incomplete. It looks
like if zmq.h was present in /usr/local/include it had precedence
over the one from libzmq folder (that we built with CMake).
This patch to CMakeFile make sure that we use the custom include
path first, thus avoiding this problem.

Problem: curve.hpp missed an include of zmq.h, therefore causing
ZMQ_VERSION_MAJOR to be undefined.
