### PR TITLE
Zap improv

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Author: Dinka Ranns <dinka.ranns@gmail.com>
 Author: Olaf Lenz <olenz@icp.uni-stuttgart.de>
 Author: Krzysztof Rapacki <shauren.dev@gmail.com>
 Author: Prem Shankar Kumar <meprem@gmail.com>
+Author: Arnaud Kapp <kapp.arno@gmail.com>

--- a/src/tests/test_auth.cpp
+++ b/src/tests/test_auth.cpp
@@ -103,24 +103,27 @@ BOOST_AUTO_TEST_CASE(woodhouse)
     authenticator.allow("127.0.0.1");
 
     // create and bind a server socket
-    zmqpp::socket server(context, zmqpp::socket_type::push);
+    zmqpp::socket server(context, zmqpp::socket_type::pull);
     server.set(zmqpp::socket_option::plain_server, 1);
     server.bind("tcp://*:9000");
 
     // create and connect a client socket
-    zmqpp::socket client(context, zmqpp::socket_type::pull);
+    zmqpp::socket client(context, zmqpp::socket_type::push);
     client.set(zmqpp::socket_option::plain_username, "admin");
     client.set(zmqpp::socket_option::plain_password, "password");
     client.connect("tcp://127.0.0.1:9000");
 
-    // Send a single message from server to client
+    // Send a single message from client to server
     zmqpp::message request;
     request << "Hello";
-    server.send(request);
+    client.send(request);
 
     zmqpp::message response;
-    client.receive(response);
+    server.receive(response);
 
+    std::string user_id;
+    BOOST_CHECK_EQUAL(true, response.get_property("User-Id", user_id));
+    BOOST_CHECK_EQUAL("admin", user_id);
     BOOST_CHECK_EQUAL("Hello", response.get(0));
 }
 
@@ -164,7 +167,7 @@ BOOST_AUTO_TEST_CASE(stonehouse)
     std::cout << "Server Secret Key :" << server_keypair.secret_key << std::endl;
 
     // create and bind a server socket
-    zmqpp::socket server(context, zmqpp::socket_type::push);
+    zmqpp::socket server(context, zmqpp::socket_type::pull);
     server.set(zmqpp::socket_option::identity, "IDENT");
     int as_server = 1;
     server.set(zmqpp::socket_option::curve_server, as_server);
@@ -172,20 +175,23 @@ BOOST_AUTO_TEST_CASE(stonehouse)
     server.bind("tcp://*:9000");
 
     // create and connect a client socket
-    zmqpp::socket client(context, zmqpp::socket_type::pull);
+    zmqpp::socket client(context, zmqpp::socket_type::push);
     client.set(zmqpp::socket_option::curve_server_key, server_keypair.public_key);
     client.set(zmqpp::socket_option::curve_public_key, client_keypair.public_key);
     client.set(zmqpp::socket_option::curve_secret_key, client_keypair.secret_key);
     client.connect("tcp://127.0.0.1:9000");
 
-    // Send a single message from server to client
+    // Send a single message from client to server
     zmqpp::message request;
     request << "Hello";
-    server.send(request);
+    client.send(request);
 
     zmqpp::message response;
-    client.receive(response);
-  
+    server.receive(response);
+
+    std::string user_id;
+    BOOST_CHECK_EQUAL(true, response.get_property("User-Id", user_id));
+    BOOST_CHECK_EQUAL(client_keypair.public_key, user_id);
     BOOST_CHECK_EQUAL("Hello", response.get(0));
 }
 

--- a/src/zmqpp/auth.cpp
+++ b/src/zmqpp/auth.cpp
@@ -20,6 +20,7 @@
 namespace zmqpp
 {
 auth::auth(context& ctx) :
+  curve_allow_any(false),
   terminated(false),
   verbose(false)
   {
@@ -196,12 +197,12 @@ void auth::handle_command(socket& pipe) {
     	std::string client_public_key = msg.get(1);
 
     	if("CURVE_ALLOW_ANY" == client_public_key) {
-    		allow_any = true;
+    		curve_allow_any = true;
             if(verbose) {
     		  std::cout << "auth: configured CURVE - allow ALL clients" << std::endl;
             }
     	} else {
-    		allow_any = false;
+    		curve_allow_any = false;
     		client_keys.insert(client_public_key);
             if(verbose) {
     		  std::cout << "auth: configured CURVE - allow client with public key:" << client_public_key << std::endl;
@@ -258,7 +259,7 @@ bool auth::authenticate_plain(zap_request& request, std::string &user_id)
 
 bool auth::authenticate_curve(zap_request& request, std::string &user_id)
 {
-	if (allow_any) {
+	if (curve_allow_any) {
     	if (verbose) {
         	std::cout << "auth: allowed (CURVE allow any client)" << std::endl;
         }
@@ -359,7 +360,6 @@ void auth::authenticate(socket& sock) {
             allowed = authenticate_gssapi(request);
         }
     }
-    std::cout << "ALLOWED" << user_id << std::endl;
     if (allowed)
     	request.reply("200", "OK", user_id);
     else

--- a/src/zmqpp/auth.cpp
+++ b/src/zmqpp/auth.cpp
@@ -13,6 +13,7 @@
 #include "exception.hpp"
 #include "socket_types.hpp"
 #include "signal.hpp"
+#include "z85.hpp"
 
 #if (ZMQ_VERSION_MAJOR > 3)
 
@@ -235,13 +236,15 @@ void auth::handle_command(socket& pipe) {
     }
 }
 
-bool auth::authenticate_plain(zap_request& request) {
+bool auth::authenticate_plain(zap_request& request, std::string &user_id)
+{
 	auto search = passwords.find(request.get_username());
     if((search != passwords.end()) && (search->second == request.get_password())) {
         if (verbose) {
             std::cout << "auth: allowed (PLAIN) username=" << request.get_username()
         		<< " password=" << request.get_password() << std::endl;
         }
+        user_id = request.get_username();
         return true;
     }
     else {
@@ -253,11 +256,13 @@ bool auth::authenticate_plain(zap_request& request) {
     }
 }
 
-bool auth::authenticate_curve(zap_request& request) {
+bool auth::authenticate_curve(zap_request& request, std::string &user_id)
+{
 	if (allow_any) {
     	if (verbose) {
         	std::cout << "auth: allowed (CURVE allow any client)" << std::endl;
         }
+        user_id = request.get_client_key();
     	return true;
 	} else {
 		auto search = client_keys.find(request.get_client_key());
@@ -265,6 +270,7 @@ bool auth::authenticate_curve(zap_request& request) {
     		if (verbose) {
         		std::cout << "auth: allowed (CURVE) client_key=" << request.get_client_key() << std::endl;
             }
+            user_id = request.get_client_key();
     		return true;
     	}
     	else {
@@ -288,8 +294,11 @@ void auth::authenticate(socket& sock) {
     // Receive a ZAP request.
 	zap_request request(sock, verbose);
 
+    // will be set by mechanism-dependent code
+    std::string user_id;
+
 	if(request.get_version().empty()) {        // Interrupted
-		request.reply("500", "Internal error");
+		request.reply("500", "Internal error", "");
     	return;     
 	}
 
@@ -339,21 +348,22 @@ void auth::authenticate(socket& sock) {
 
         } else if ("PLAIN" == request.get_mechanism()) {
             // For PLAIN, even a whitelisted address must authenticate
-            allowed = authenticate_plain(request);
+            allowed = authenticate_plain(request, user_id);
 
         } else if ("CURVE" == request.get_mechanism()) {
             // For CURVE, even a whitelisted address must authenticate
-            allowed = authenticate_curve(request);
+            allowed = authenticate_curve(request, user_id);
 
         } else if ("GSSAPI" == request.get_mechanism()) {
             // For GSSAPI, even a whitelisted address must authenticate
             allowed = authenticate_gssapi(request);
         }
     }
+    std::cout << "ALLOWED" << user_id << std::endl;
     if (allowed)
-    	request.reply("200", "OK");
+    	request.reply("200", "OK", user_id);
     else
-        request.reply("400", "No access");
+        request.reply("400", "No access", "");
 }
 
 }

--- a/src/zmqpp/auth.hpp
+++ b/src/zmqpp/auth.hpp
@@ -144,7 +144,7 @@ private:
     	std::unordered_map<std::string, std::string> 	passwords;      // PLAIN passwords, if loaded
     	std::unordered_set<std::string> 		client_keys;    // Client public keys
     	std::string 				 	domain;			// ZAP domain
-    	bool 					 	allow_any;      // CURVE allows arbitrary clients
+    	bool                        curve_allow_any;      // CURVE allows arbitrary clients
     	bool 					 	terminated;     // Did caller ask us to quit?
     	bool 					 	verbose;        // Verbose logging enabled?
 

--- a/src/zmqpp/auth.hpp
+++ b/src/zmqpp/auth.hpp
@@ -114,14 +114,16 @@ private:
 	/*!
 	 * Handle a PLAIN authentication request from libzmq core
 	 *
+	 * @param user_id store the user as the User-Id.
 	 */
-    	bool authenticate_plain(zap_request& request);
+    	bool authenticate_plain(zap_request& request, std::string &user_id);
 
 	/*!
 	 * Handle a CURVE authentication request from libzmq core
 	 *
+	 * @param user_id store the public key (z85 encoded) as the User-Id.
 	 */
-    	bool authenticate_curve(zap_request& request);
+    	bool authenticate_curve(zap_request& request, std::string &user_id);
 
     	/*!
 	 * Handle a GSSAPI authentication request from libzmq core

--- a/src/zmqpp/message.cpp
+++ b/src/zmqpp/message.cpp
@@ -483,4 +483,29 @@ bool message::is_signal() const
     return false;
 }
 
+#if (ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 1)
+bool message::get_property(const std::string &property, std::string &out)
+{
+	zmq_msg_t *zmq_raw_msg;
+	try
+	{
+		zmq_raw_msg = &raw_msg();
+	}
+	catch (zmqpp::exception &e) // empty
+	{
+		return false;
+	}
+
+	const char *property_value = zmq_msg_gets(zmq_raw_msg, property.c_str());
+	if (property_value == NULL)
+	{
+		// EINVAL is the only error code
+		assert(errno == EINVAL);
+		return false;
+	}
+
+	out = std::string(property_value);
+	return true;
+}
+#endif
 }

--- a/src/zmqpp/message.hpp
+++ b/src/zmqpp/message.hpp
@@ -267,6 +267,18 @@ public:
 	 * @return the new read_cursor
 	 */
 	size_t next() NOEXCEPT { return ++_read_cursor; }
+
+
+#if (ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 1)
+	/**
+	* Attemps to retrieve a metadata property from a message.
+	* The underlying call is `zmq_msg_gets()`.
+	*
+	* @note The message MUST have at least one frame, otherwise this wont work.
+	*/
+	bool get_property(const std::string &property, std::string &out);
+#endif
+
 private:
 	typedef std::vector<frame> parts_type;
 	parts_type _parts;

--- a/src/zmqpp/socket_options.hpp
+++ b/src/zmqpp/socket_options.hpp
@@ -91,7 +91,6 @@ ZMQPP_COMPARABLE_ENUM socket_option {
  #if (ZMQ_VERSION_MAJOR > 4) || ((ZMQ_VERSION_MAJOR == 4) && (ZMQ_VERSION_MINOR >= 1))
 	handshake_interval        = ZMQ_HANDSHAKE_IVL, /*!< Maximum handshake interval */
 	type_of_service           = ZMQ_TOS, /*!< Type-of-Service socket override status */
-	identity_fd               = ZMQ_IDENTITY_FD, /*!< FD associated with given identity - get only */
 	connect_rid               = ZMQ_CONNECT_RID, /*!< Assign the next outbound connection id - set only */
 	ipc_filter_gid            = ZMQ_IPC_FILTER_GID, /*!< Group ID filters to allow new IPC connections - set only */
 	ipc_filter_pid            = ZMQ_IPC_FILTER_PID, /*!< Process ID filters to allow new IPC connections - set only */

--- a/src/zmqpp/zap_request.cpp
+++ b/src/zmqpp/zap_request.cpp
@@ -60,17 +60,21 @@ zap_request::zap_request(socket& handler, bool logging) :
 /*! 
  * Send a ZAP reply to the handler socket
  */
-void zap_request::reply (std::string status_code, std::string status_text) {
-    if (verbose) {
-        std::cout << "auth: ZAP reply status_code=" << status_code
-            << " status_text=" << status_text << std::endl;
-    }
+void zap_request::reply(const std::string &status_code, const std::string &status_text,
+            const std::string &user_id)
+    {
+        if (verbose)
+        {
+            std::cout << "auth: ZAP reply status_code=" << status_code
+                    << " status_text=" << status_text <<
+                    " user_id=" << user_id << std::endl;
+        }
 
-    message reply;
-    reply << version << sequence << status_code << status_text << "" << "";
-    
-    zap_socket.send(reply);
-}    
+        message reply;
+        reply << version << sequence << status_code << status_text << user_id << "";
+
+        zap_socket.send(reply);
+    }
 
 }
 

--- a/src/zmqpp/zap_request.hpp
+++ b/src/zmqpp/zap_request.hpp
@@ -31,7 +31,8 @@ public:
     /*! 
      * Send a ZAP reply to the handler socket
      */
-    void reply (std::string status_code, std::string status_text);
+    void reply(const std::string &status_code, const std::string &status_text,
+            const std::string &user_id);
 
     /*! 
      * Get Version
@@ -83,7 +84,8 @@ public:
     }
 
     /*! 
-     * Get client_key for CURVE security mechanism
+     * Get client_key for CURVE security mechanism.
+     * The key is z85 encoded.
      */
     const std::string & get_client_key() const {
         return client_key;


### PR DESCRIPTION
Add a wrapper around `zmq_msg_gets()`. This is the `message::get_property()` method.

Modify the current ZAP module to populate the `user-id` when available:
+ with PLAIN by using the username.
+ with CURVE by using the client's public key.

Drop support of ZMQ_IDENTITY_FD.