### PR TITLE
Compilation fix for zmqpp-client on Mac OS X 10.10

### DIFF
--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -42,7 +42,11 @@ int main(int argc, char const* argv[])
 	if( options.show_usage || options.show_help )
 	{
 		show_usage( std::cout, BUILD_CLIENT_NAME );
-		if( options.show_help ) { std::cout << std::endl << show_help( std::cout ); }
+		if( options.show_help )
+		{
+			std::cout << std::endl;
+			show_help( std::cout );
+		}
 
 		return EXIT_FAILURE;
 	}
@@ -226,7 +230,7 @@ int main(int argc, char const* argv[])
 				while( result && (length = strlen( buffer.data() ) - 1) > 0 ) // trim newline from gets
 				{
 					buffer[length] = 0;
-					message.add( buffer.data(), length );
+					message.add( buffer.data(), static_cast<uint64_t>(length) );
 
 					if( options.singlepart ) { break; }
 

--- a/src/client/options.cpp
+++ b/src/client/options.cpp
@@ -24,6 +24,11 @@
 
 #include "options.hpp"
 
+#ifndef BUILD_CLIENT_NAME
+#define BUILD_CLIENT_NAME "zmqpp"
+#endif
+
+
 boost::program_options::options_description connection_options()
 {
 	boost::program_options::options_description options("Connection Options");


### PR DESCRIPTION
Hello,

These changes were needed to compile zmqpp-client on a Mac running OS X 10.10. zmqpp was configured using the CMake scripts and compiled with Xcode 6.1.