### PR TITLE
Update requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ configuration file to generate them is in the root directory.
 
 To build the documentation with doxygen use
 
-    doxygen zmqpp.doxygen.conf
+    doxygen
 
 And the resulting html or latex docs will be in the docs/html or docs/latex
 directories.
@@ -72,8 +72,8 @@ the library itself.
 Requirements
 ------------
 
-ZeroMQ 2.2.x or later
-C++0x compliant compiler
+ZeroMQ 2.2.x or later. We recommend to use ZeroMQ >= 3.
+C++11 compliant compiler. (g++ >= 4.7)
 
 The command line client and the tests also require libboost.
 


### PR DESCRIPTION
It's been pointed out (#105) that C++0x wasn't enough to build
the develop branch anymore.

This commits update the requirement to a C++11 compatible compiler.
It fixes #105.

The recommendation for ZMQ >= 3 is because iirc we may have trouble building the tests against zmq 2.2.