### PR TITLE
add cstdlib header to ensure EXIT_FAILURE presence

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Author: Olaf Lenz <olenz@icp.uni-stuttgart.de>
 Author: Krzysztof Rapacki <shauren.dev@gmail.com>
 Author: Prem Shankar Kumar <meprem@gmail.com>
 Author: Arnaud Kapp <kapp.arno@gmail.com>
+Author: Lionel Orry <lionel.orry@gmail.com>

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -12,6 +12,7 @@
  *      Author: @benjamg
  */
 
+#include <cstdlib>
 #include <array>
 #include <iostream>
 #include <tuple>


### PR DESCRIPTION
Using some cross-compiling toolchains, EXIT_FAILURE is not always
properly defined without this inclusion.

Add myself to AUTHORS.

Signed-off-by: Lionel Orry <lionel.orry@gmail.com>