### PR TITLE
VC2013 compile fix (no support for constexpr).

### DIFF
--- a/src/zmqpp/auth.cpp
+++ b/src/zmqpp/auth.cpp
@@ -26,6 +26,10 @@
 
 #if (ZMQ_VERSION_MAJOR > 3)
 
+#if defined(ZMQPP_NO_CONSTEXPR)
+	const char * const zmqpp::auth::zap_endpoint_ = "inproc://zeromq.zap.01";
+#endif
+
 namespace zmqpp
 {
 auth::auth(context& ctx) :

--- a/src/zmqpp/auth.hpp
+++ b/src/zmqpp/auth.hpp
@@ -157,7 +157,11 @@ private:
     	bool 					 	terminated;     // Did caller ask us to quit?
     	bool 					 	verbose;        // Verbose logging enabled?
 
+#	if defined(ZMQPP_NO_CONSTEXPR)
+        static const char * const zap_endpoint_;
+#	else
         constexpr static const char * const zap_endpoint_ = "inproc://zeromq.zap.01";
+#	endif
   
     	// No copy - private and not implemented
     	auth(auth const&) ZMQPP_EXPLICITLY_DELETED;

--- a/src/zmqpp/compatibility.hpp
+++ b/src/zmqpp/compatibility.hpp
@@ -78,6 +78,9 @@
 
 #if defined(_MSC_VER)
 #define NOEXCEPT throw()
+#if _MSC_VER < 1900
+#	define ZMQPP_NO_CONSTEXPR
+#endif
 #if _MSC_VER < 1800
 #define ZMQPP_EXPLICITLY_DELETED
 #endif // if _MSC_VER < 1800


### PR DESCRIPTION
A new define ZMQPP_NO_CONSTEXPR was introduced in compatibility.h. It is
set for all versions of VC++ including VC2013. VC2015 should have
support for constexpr but needs to be tested when it is available.

This fixes #99.