### PR TITLE
Improved the api dealing with file descriptors (see  #111).

### DIFF
--- a/src/zmqpp/compatibility.hpp
+++ b/src/zmqpp/compatibility.hpp
@@ -104,5 +104,19 @@
 #define NOEXCEPT noexcept
 #endif
 
+// There are a couple of methods that take a raw socket in form of a 'file descriptor'. Under POSIX
+// this is simply an int. But under Windows this type must be a SOCKET. In order to hide this 
+// platform detail we create a raw_socket_t which is a SOCKET under Windows and an int on all the
+// other platforms. This is practically the same as libzmq does with its zmq_pollitem_t struct.
+namespace zmqpp
+{
+#ifdef _WIN32
+	typedef SOCKET raw_socket_t;
+#else
+	typedef int raw_socket_t;
+#endif
+}
+
+
 #endif /* ZMQPP_COMPATIBILITY_HPP_ */
 

--- a/src/zmqpp/poller.cpp
+++ b/src/zmqpp/poller.cpp
@@ -55,7 +55,7 @@ void poller::add(socket& socket, short const event /* = POLL_IN */)
 	_index[socket] = index;
 }
 
-void poller::add(int const descriptor, short const event /* = POLL_IN */)
+void poller::add(raw_socket_t const descriptor, short const event /* = POLL_IN */)
 {
 	zmq_pollitem_t item { nullptr, descriptor, event, 0 };
 
@@ -80,7 +80,7 @@ bool poller::has(socket_t const& socket)
 	return _index.find(socket) != _index.end();
 }
 
-bool poller::has(int const descriptor)
+bool poller::has(raw_socket_t const descriptor)
 {
 	return _fdindex.find(descriptor) != _fdindex.end();
 }
@@ -129,7 +129,7 @@ void poller::remove(socket_t const& socket)
 	reindex( index );
 }
 
-void poller::remove(int const descriptor)
+void poller::remove(raw_socket_t const descriptor)
 {
 	auto found = _fdindex.find(descriptor);
 	if (_fdindex.end() == found) { return; }
@@ -185,12 +185,12 @@ void poller::check_for(socket const& socket, short const event)
 	_items[found->second].events = event;
 }
 
-void poller::check_for(int const descriptor, short const event)
+void poller::check_for(raw_socket_t const descriptor, short const event)
 {
 	auto found = _fdindex.find(descriptor);
 	if (_fdindex.end() == found)
 	{
-		throw exception("this socket is not represented within this poller");
+		throw exception("this standard socket is not represented within this poller");
 	}
 
 	_items[found->second].events = event;
@@ -241,12 +241,12 @@ short poller::events(socket const& socket) const
 	return _items[found->second].revents;
 }
 
-short poller::events(int const descriptor) const
+short poller::events(raw_socket_t const descriptor) const
 {
 	auto found = _fdindex.find(descriptor);
 	if (_fdindex.end() == found)
 	{
-		throw exception("this file descriptor is not represented within this poller");
+		throw exception("this standard socket is not represented within this poller");
 	}
 
 	return _items[found->second].revents;

--- a/src/zmqpp/poller.hpp
+++ b/src/zmqpp/poller.hpp
@@ -31,7 +31,7 @@ typedef socket socket_t;
 /*!
  * Polling wrapper.
  *
- * Allows access to polling for any number of sockets or file descriptors.
+ * Allows access to polling for any number of zmq sockets or standard sockets.
  */
 class poller
 {
@@ -68,12 +68,12 @@ public:
 	void add(socket_t& socket, short const event = poll_in);
 
 	/*!
-	 * Add a file descriptor to the polling model and set which events to monitor.
+	 * Add a standard socket to the polling model and set which events to monitor.
 	 *
-	 * \param descriptor the file descriptor to monitor.
+	 * \param descriptor the raw socket to monitor (SOCKET under Windows, a file descriptor otherwise).
 	 * \param event the event flags to monitor.
 	 */
-	void add(int const descriptor, short const event = poll_in | poll_error);
+	void add(raw_socket_t const descriptor, short const event = poll_in | poll_error);
 
 	/*!
 	 * Add a zmq_pollitem_t to the poller; Events to monitor are already configured.
@@ -93,12 +93,12 @@ public:
 	 bool has(socket_t const& socket);
 
 	/*!
-	 * Check if we are monitoring a given file descriptor with this poller.
+	 * Check if we are monitoring a given standard socket with this poller.
 	 *
-	 * \param descriptor the file descriptor to check.
+	 * \param descriptor the raw socket to check for.
 	 * \return true if it is there.
 	 */
-	bool has(int const descriptor);
+	 bool has(raw_socket_t const descriptor);
 
 	/*!
 	 * Check if we are monitoring a given pollitem.
@@ -118,11 +118,11 @@ public:
 	void remove(socket_t const& socket);
 	
 	/*!
-	 * Stop monitoring a file descriptor.
+	 * Stop monitoring a standard socket.
 	 *
-	 * \param descriptor the file descriptor to stop monitoring.
+	 * \param descriptor the raw socket to stop monitoring (SOCKET under Windows, a file descriptor otherwise).
 	 */
-	void remove(int const descriptor);
+	void remove(raw_socket_t const descriptor);
 
 	/*!
 	 * Stop monitoring a zmq_pollitem_t
@@ -140,12 +140,12 @@ public:
 	void check_for(socket_t const& socket, short const event);
 	
 	/*!
-	 * Update the monitored event flags for a given file descriptor.
+	 * Update the monitored event flags for a given standard socket.
 	 *
-	 * \param descriptor the file descriptor to update event flags.
+	 * \param descriptor the raw socket to update event flags (SOCKET under Windows, a file descriptor otherwise).
 	 * \param event the event flags to monitor on the socket.
 	 */
-	void check_for(int const descriptor, short const event);
+	void check_for(raw_socket_t const descriptor, short const event);
 	
 	/*!
 	 * Update the monitored event flags for a given zmq_pollitem_t
@@ -177,12 +177,12 @@ public:
 	short events(socket_t const& socket) const;
 	
 	/*!
-	 * Get the event flags triggered for a file descriptor.
+	 * Get the event flags triggered for a standard socket.
 	 *
-	 * \param descriptor the file descriptor to get triggered event flags for.
+	 * \param descriptor the raw socket to get triggered event flags for (SOCKET under Windows, a file descriptor otherwise).
 	 * \return the event flags.
 	 */
-	short events(int const descriptor) const;
+	short events(raw_socket_t const descriptor) const;
 	
 	/*!
 	 * Get the event flags triggered for a zmq_pollitem_t
@@ -193,36 +193,36 @@ public:
 	short events(const zmq_pollitem_t &item) const;
 
 	/*!
-	 * Check either a file descriptor or socket for input events.
+	 * Check either a standard socket or zmq socket for input events.
 	 *
 	 * Templated helper method that calls through to event and checks for a given flag
 	 *
-	 * \param watchable either a file descriptor or socket known to the poller.
+	 * \param watchable either a standard socket or socket known to the poller.
 	 * \return true if there is input.
 	 */
 	template<typename Watched>
 	bool has_input(Watched const& watchable) const { return (events(watchable) & poll_in) != 0; }
 
 	/*!
-	 * Check either a file descriptor or socket for output events.
+	 * Check either a standard socket or zmq socket for output events.
 	 *
 	 * Templated helper method that calls through to event and checks for a given flag
 	 *
-	 * \param watchable either a file descriptor or socket known to the poller.
+	 * \param watchable either a standard socket or zmq socket known to the poller.
 	 * \return true if there is output.
 	 */
 	template<typename Watched>
 	bool has_output(Watched const& watchable) const { return (events(watchable) & poll_out) != 0; }
 
 	/*!
-	 * Check a file descriptor.
+	 * Check a standard socket (file descriptor or SOCKET).
 	 *
 	 * Templated helper method that calls through to event and checks for a given flag
 	 *
 	 * Technically this template works for sockets as well but the error flag is never set for
 	 * sockets so I have no idea why someone would call it.
 	 *
-	 * \param watchable a file descriptor know to the poller.
+	 * \param watchable a standard socket known to the poller.
 	 * \return true if there is an error.
 	 */
 	template<typename Watched>
@@ -231,7 +231,7 @@ public:
 private:
 	std::vector<zmq_pollitem_t> _items;
 	std::unordered_map<void *, size_t> _index;
-	std::unordered_map<int, size_t> _fdindex;
+	std::unordered_map<raw_socket_t, size_t> _fdindex;
 
 	void reindex(size_t const index);
 };

--- a/src/zmqpp/reactor.cpp
+++ b/src/zmqpp/reactor.cpp
@@ -37,7 +37,7 @@ namespace zmqpp
         add(item, callable);
     }
 
-    void reactor::add(int const descriptor, Callable callable, short const event /* = POLL_IN */)
+    void reactor::add(raw_socket_t const descriptor, Callable callable, short const event /* = POLL_IN */)
     {
         zmq_pollitem_t item{nullptr, descriptor, event, 0};
         add(item, callable);
@@ -55,7 +55,7 @@ namespace zmqpp
         return poller_.has(socket);
     }
 
-    bool reactor::has(int const descriptor)
+    bool reactor::has(raw_socket_t const descriptor)
     {
         return poller_.has(descriptor);
     }
@@ -79,7 +79,7 @@ namespace zmqpp
         poller_.remove(socket);
     }
 
-    void reactor::remove(int const descriptor)
+    void reactor::remove(raw_socket_t const descriptor)
     {
         if (dispatching_)
         {
@@ -103,7 +103,7 @@ namespace zmqpp
         poller_.check_for(socket, event);
     }
 
-    void reactor::check_for(int const descriptor, short const event)
+    void reactor::check_for(raw_socket_t const descriptor, short const event)
     {
         poller_.check_for(descriptor, event);
     }
@@ -132,7 +132,7 @@ namespace zmqpp
         return poller_.events(socket);
     }
 
-    short reactor::events(int const descriptor) const
+    short reactor::events(raw_socket_t const descriptor) const
     {
         return poller_.events(descriptor);
     }
@@ -149,7 +149,7 @@ namespace zmqpp
 
     void reactor::flush_remove_later()
     {
-        for (int fd : fdRemoveLater_)
+        for (raw_socket_t fd : fdRemoveLater_)
             remove(fd);
         for (const socket_t *sock : sockRemoveLater_)
             remove(*sock);

--- a/src/zmqpp/reactor.hpp
+++ b/src/zmqpp/reactor.hpp
@@ -56,13 +56,13 @@ namespace zmqpp
         void add(socket_t& socket, Callable callable, short const event = poller::poll_in);
 
         /*!
-         * Add a file descriptor to the reactor, providing a handler that will be called when the monitored events occur.
+         * Add a standard socket to the reactor, providing a handler that will be called when the monitored events occur.
          *
-         * \param descriptor the file descriptor to monitor.
+         * \param descriptor the standard socket to monitor (SOCKET under Windows, a file descriptor otherwise).
          * \param callable the function that will be called by the reactor when a registered event occurs on fd.
          * \param event the event flags to monitor.
          */
-        void add(int const descriptor, Callable callable, short const event = poller::poll_in | poller::poll_error);
+        void add(raw_socket_t const descriptor, Callable callable, short const event = poller::poll_in | poller::poll_error);
 
         /*!
          * Check if we are monitoring a given socket with this reactor.
@@ -73,12 +73,12 @@ namespace zmqpp
         bool has(socket_t const& socket);
 
         /*!
-         * Check if we are monitoring a given file descriptor with this reactor.
+         * Check if we are monitoring a given standard socket with this reactor.
          *
-         * \param descriptor the file descriptor to check.
+         * \param descriptor the raw socket to check (SOCKET under Windows, a file descriptor otherwise).
          * \return true if it is there.
          */
-        bool has(int const descriptor);
+        bool has(raw_socket_t const descriptor);
 
         /*!
          * Stop monitoring a socket.
@@ -88,11 +88,11 @@ namespace zmqpp
         void remove(socket_t const& socket);
 
         /*!
-         * Stop monitoring a file descriptor.
+         * Stop monitoring a standard socket.
          *
-         * \param descriptor the file descriptor to stop monitoring.
+         * \param descriptor the standard socket to stop monitoring.
          */
-        void remove(int const descriptor);
+        void remove(raw_socket_t const descriptor);
 
         /*!
          * Update the monitored event flags for a given socket.
@@ -103,12 +103,12 @@ namespace zmqpp
         void check_for(socket_t const& socket, short const event);
 
         /*!
-         * Update the monitored event flags for a given file descriptor.
+         * Update the monitored event flags for a given standard socket.
          *
-         * \param descriptor the file descriptor to update event flags.
+         * \param descriptor the raw socket to update event flags (SOCKET under Windows, a file descriptor otherwise).
          * \param event the event flags to monitor on the socket.
          */
-        void check_for(int const descriptor, short const event);
+        void check_for(raw_socket_t const descriptor, short const event);
 
         /*!
          * Poll for monitored events and call associated handler when needed.
@@ -132,12 +132,12 @@ namespace zmqpp
         short events(socket_t const& socket) const;
 
         /*!
-         * Get the event flags triggered for a file descriptor.
+         * Get the event flags triggered for a standard socket.
          *
-         * \param descriptor the file descriptor to get triggered event flags for.
+         * \param descriptor the raw socket to get triggered event flags for (SOCKET under Windows, a file descriptor otherwise).
          * \return the event flags.
          */
-        short events(int const descriptor) const;
+        short events(raw_socket_t const descriptor) const;
 
 
         /**
@@ -158,7 +158,7 @@ namespace zmqpp
     private:
         std::vector<PollItemCallablePair> items_;
         std::vector<const socket_t *> sockRemoveLater_;
-        std::vector<int> fdRemoveLater_;
+        std::vector<raw_socket_t> fdRemoveLater_;
       
       /**
        * Flush the fdRemoveLater_ and sockRemoveLater_ vector, effectively removing


### PR DESCRIPTION
Until now adding raw sockets to poller and reactor was done using a file
descriptor as an int. This only works properly under POSIX. Under Windows
a raw socket is represented as a SOCKET type. This type cannot simply be
cast into int because under 32-bit it is actually an unsigned int and
under 64-bit it is an unsigned __int64.

The problem was solved by introducing a new typedef raw_socket_t which
is of type SOCKET under Windows and an int under the other platforms.
All methods taking an int as a file descriptor now take raw_socket_t
hiding this platform detail away.

The documention was changed accordingly to talk about 'standard socket'
where 'file descriptor' was used before.

This is a api-breaking change (at least under Windows).

This fixes #111.