### PR TITLE
Fixed some api inconsistencies.

### DIFF
--- a/src/zmqpp/poller.cpp
+++ b/src/zmqpp/poller.cpp
@@ -62,13 +62,13 @@ void poller::add(raw_socket_t const descriptor, short const event /* = POLL_IN *
 
 void poller::add(zmq_pollitem_t const& item)
 {
-        size_t index = _items.size();
+	size_t index = _items.size();
 
-        _items.push_back(item);
-        if (nullptr == item.socket)
-            _fdindex[item.fd] = index;
-        else
-            _index[item.socket] = index;
+	_items.push_back(item);
+	if (nullptr == item.socket)
+		_fdindex[item.fd] = index;
+	else
+		_index[item.socket] = index;
 }
 
 bool poller::has(socket_t const& socket)
@@ -81,11 +81,11 @@ bool poller::has(raw_socket_t const descriptor)
 	return _fdindex.find(descriptor) != _fdindex.end();
 }
 
-bool poller::has(const zmq_pollitem_t &item)
+bool poller::has(zmq_pollitem_t const& item)
 {
-        if (nullptr != item.socket)
-            return _index.find(item.socket) != _index.end();
-        return _fdindex.find(item.fd) != _fdindex.end();
+	if (nullptr != item.socket)
+		return _index.find(item.socket) != _index.end();
+	return _fdindex.find(item.fd) != _fdindex.end();
 }
 
 void poller::reindex(size_t const index)
@@ -118,7 +118,7 @@ void poller::remove(raw_socket_t const descriptor)
 	remove(item);
 }
 
-void poller::remove(const zmq_pollitem_t &item)
+void poller::remove(zmq_pollitem_t const& item)
 {
     if (nullptr == item.socket)
       return remove(item.fd);
@@ -164,7 +164,7 @@ void poller::check_for(raw_socket_t const descriptor, short const event)
 	_items[found->second].events = event;
 }
 
-void poller::check_for(const zmq_pollitem_t &item, short const event)
+void poller::check_for(zmq_pollitem_t const& item, short const event)
 {
 
         if (nullptr == item.socket)
@@ -220,7 +220,7 @@ short poller::events(raw_socket_t const descriptor) const
 	return _items[found->second].revents;
 }
 
-short poller::events(const zmq_pollitem_t &item) const
+short poller::events(zmq_pollitem_t const& item) const
 {
         if (nullptr == item.socket)
         {

--- a/src/zmqpp/poller.cpp
+++ b/src/zmqpp/poller.cpp
@@ -60,7 +60,7 @@ void poller::add(raw_socket_t const descriptor, short const event /* = POLL_IN *
 	add(item);
 }
 
-void poller::add(zmq_pollitem_t item)
+void poller::add(zmq_pollitem_t const& item)
 {
         size_t index = _items.size();
 

--- a/src/zmqpp/poller.hpp
+++ b/src/zmqpp/poller.hpp
@@ -108,7 +108,7 @@ public:
 	 * \param item the pollitem to check for
 	 * \return true if it is there.
 	 */
-	bool has(const zmq_pollitem_t &item);
+	bool has(zmq_pollitem_t const& item);
 
 	/*!
 	 * Stop monitoring a socket.
@@ -129,7 +129,7 @@ public:
 	 *
 	 * \param item the pollitem to stop monitoring.
 	 */
-	void remove(const zmq_pollitem_t &item);
+	void remove(zmq_pollitem_t const& item);
 
 	/*!
 	 * Update the monitored event flags for a given socket.
@@ -153,7 +153,7 @@ public:
 	 * \param item the item to change event flags for.
 	 * \param event the event flags to monitor on the socket.
 	 */
-	void check_for(const zmq_pollitem_t &item, short const event);
+	void check_for(zmq_pollitem_t const& item, short const event);
 	
 	/*!
 	 * Poll for monitored events.
@@ -190,7 +190,7 @@ public:
 	 * \param item the pollitem to get triggered event flags for.
 	 * \return the event flags.
 	 */
-	short events(const zmq_pollitem_t &item) const;
+	short events(zmq_pollitem_t const& item) const;
 
 	/*!
 	 * Check either a standard socket or zmq socket for input events.

--- a/src/zmqpp/poller.hpp
+++ b/src/zmqpp/poller.hpp
@@ -82,7 +82,7 @@ public:
 	 *
 	 * \param item the pollitem to be added
 	 */
-	void add(zmq_pollitem_t item);
+	void add(zmq_pollitem_t const& item);
 
 	 /*!
 	  * Check if we are monitoring a given socket with this poller.


### PR DESCRIPTION
* poller::add(zmq_pollitem_t) takes a const reference just like the other methods
* poller declares const references as "foo const&" consistently now