### PR TITLE
Silenced some VC++ compiler warnings.

### DIFF
--- a/src/zmqpp/actor.cpp
+++ b/src/zmqpp/actor.cpp
@@ -120,23 +120,21 @@ namespace zmqpp
 
     std::string actor::bind_parent()
     {
-      std::string base_endpoint = "inproc://zmqpp::actor::" + std::to_string(reinterpret_cast<ptrdiff_t> (this));
-	
-	while (true)
-	  {
-	    try
-	      {
-		std::string endpoint = base_endpoint + std::to_string(std::rand());
-		parent_pipe_->bind(endpoint);
-		return endpoint;
-	      }
-	    catch (zmq_internal_exception &e)
-	      {
-		// endpoint already taken.
-	      }
-	  }
+        std::string base_endpoint = "inproc://zmqpp::actor::" + std::to_string(reinterpret_cast<ptrdiff_t> (this));
 
-
+        for (;;)
+        {
+            try
+            {
+                std::string endpoint = base_endpoint + std::to_string(std::rand());
+                parent_pipe_->bind(endpoint);
+                return endpoint;
+            }
+            catch (zmq_internal_exception const&)
+            {
+                // endpoint already taken.
+            }
+        }
     }
 
 }

--- a/src/zmqpp/auth.cpp
+++ b/src/zmqpp/auth.cpp
@@ -44,7 +44,7 @@ auth::auth(context& ctx) :
             zap_handler.bind(zap_endpoint_);
             pipe->send(signal::ok);
         }
-        catch (zmq_internal_exception &e) {
+        catch (zmq_internal_exception const&) {
             // by returning false here, the actor will send signal::ko
             // this will make the actor constructor throw.
             // we could also to the ourselves: pipe->send(signal::ko);)

--- a/src/zmqpp/message.cpp
+++ b/src/zmqpp/message.cpp
@@ -500,7 +500,7 @@ bool message::get_property(const std::string &property, std::string &out)
 	{
 		zmq_raw_msg = &raw_msg();
 	}
-	catch (zmqpp::exception &e) // empty
+	catch (zmqpp::exception const&) // empty
 	{
 		return false;
 	}

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -845,7 +845,7 @@ void socket::monitor(endpoint_t const monitor_endpoint, int events_required)
 
 signal socket::wait()
 {
-    while (true)
+    for (;;)
     {
         message msg;
         while(!receive(msg));


### PR DESCRIPTION
Converted two while(true) loops into for(;;) in order to avoid:
"warning C4127: conditional expression is constant".

Removed the variable name from two catch blocks to avoid:
"warning C4101: 'e' : unreferenced local variable".