### PR TITLE
Documentation improvement + switch to 4.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 Development
 ===========
 
+
+
+Version 4.1.2
+=============
+
+* Fix a compilation bug (#119)
+* Improve documentation
+
 Version 4.1.1
 =============
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -32,13 +32,13 @@ PROJECT_NAME           = zmqpp
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 4.1.1
+PROJECT_NUMBER         = 4.1.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer
 # a quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "C++ bindings for 0mq"
+PROJECT_BRIEF          = "C++ bindings for 0mq (libzmq)"
 
 # With the PROJECT_LOGO tag one can specify an logo or icon that is
 # included in the documentation. The maximum height of the logo should not

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ AR       = ar
 LIBRARY_NAME     = zmqpp
 VERSION_MAJOR    = 4
 VERSION_MINOR    = 1
-VERSION_REVISION = 1
+VERSION_REVISION = 2
 
 #
 # Paths

--- a/src/mainpage.md
+++ b/src/mainpage.md
@@ -1,0 +1,43 @@
+@mainpage
+
+Introduction
+------------
+
+zmqpp is a "high-level" C++ binding for 0mq/zmq. The "high-level" term is used in
+comparison to [cppzmq](https://github.com/zeromq/cppzmq) which is somewhat a raw wrapper
+around the [libzmq](https://github.com/zeromq/libzmq) C interface.
+
+The library is documented and has a nice test suite. This doesn't mean that the library is bug
+free or that the test suite is 100% complete.
+
+The development takes places in this [GitHub repository](http://github.com/zeromq/zmqpp).
+
+
+Features
+---------
+
+Basic features:
+
++ zmqpp provides most feature from libzmq in a C++ style API.
++ It supports multiple version of [libzmq](https://github.com/zeromq/libzmq).
+
+Being built on top of libzmq, and being a higher-level binding, zmqpp provides some
+additional features:
+
++ [Reactor](@ref zmqpp::reactor) pattern.
++ [Actor](@ref zmqpp::actor) pattern.
++ Support for ZAP.
+
+
+Examples
+--------
+
+zmqpp comes a few examples. These can be found [here](https://github.com/zeromq/zmqpp/tree/develop/examples).
+
+Reading the documentation is a good way to start learning about zmqpp.
+The most important classes that you will likely use are thoses:
+
++ [Context](@ref zmqpp::context).
++ [Socket](@ref zmqpp::socket).
++ [Message](@ref zmqpp::message).
++ And either a [Poller](@ref zmqpp::poller) or a [Reactor](@ref zmqpp::reactor).

--- a/src/zmqpp/auth.hpp
+++ b/src/zmqpp/auth.hpp
@@ -35,7 +35,7 @@
 namespace zmqpp
 {
 
-/*!
+/**
  * auth - authentication for ZeroMQ security mechanisms
  * 
  * An auth actor takes over authentication for all incoming connections in
@@ -46,7 +46,7 @@ namespace zmqpp
 class auth 
 {
 public:
-	/*!
+	/**
 	 * Constructor. A auth actor takes over authentication for all incoming connections in
 	 * its context. You can whitelist or blacklist peers based on IP address,
 	 * and define policies for securing PLAIN, CURVE, and GSSAPI connections.
@@ -54,13 +54,13 @@ public:
 	 */
 	auth(context& ctx);
 
-	/*!
+	/**
 	 * Destructor.
 	 *
 	 */
     	~auth();
 
-	/*!
+	/**
 	 * Allow (whitelist) a single IP address. For NULL, all clients from this
 	 * address will be accepted. For PLAIN and CURVE, they will be allowed to
 	 * continue with authentication. You can call this method multiple times
@@ -70,7 +70,7 @@ public:
 	 */
     	void allow(const std::string &address);
 
-    	/*!
+    	/**
 	 * Deny (blacklist) a single IP address. For all security mechanisms, this
 	 * rejects the connection without any further authentication. Use either a
      	 * whitelist, or a blacklist, not not both. If you define both a whitelist
@@ -79,19 +79,19 @@ public:
 	 */
     	void deny(const std::string &address);
 
-    	/*!
+    	/**
 	 * Configure a ZAP domain. To cover all domains, use "*".
 	 */
     	void configure_domain(const std::string &domain);
 
-    	/*!
+    	/**
 	 * Configure PLAIN authentication. PLAIN authentication uses a plain-text 
 	 * username and password.
 	 *
 	 */
     	void configure_plain(const std::string &username, const std::string &password);
 
-    	/*!
+    	/**
 	 * Configure CURVE authentication. CURVE authentication uses client public keys. 
 	 * This method can be called multiple times. To cover all domains, use "*". 
 	 * To allow all client keys without checking, specify CURVE_ALLOW_ANY for the client_public_key.
@@ -99,7 +99,7 @@ public:
 	 */
     	void configure_curve(const std::string &client_public_key);
 
-    	/*!
+    	/**
 	 * Configure GSSAPI authentication. GSSAPI authentication uses an underlying 
 	 * mechanism (usually Kerberos) to establish a secure context and perform mutual 
 	 * authentication.
@@ -107,40 +107,38 @@ public:
 	 */
     	void configure_gssapi();
 
-    	/*!
+    	/**
 	 * Enable verbose tracing of commands and activity.
 	 *
 	 */
     	void set_verbose(bool verbose);
 
 private:
-	/*!
+	/**
 	 * Handle an authentication command from calling application.
 	 *
 	 */
     	void handle_command(socket& pipe);
 
-	/*!
+	/**
 	 * Handle a PLAIN authentication request from libzmq core
 	 *
-	 * @param user_id store the user as the User-Id.
 	 */
-    	bool authenticate_plain(zap_request& request, std::string &user_id);
+    	bool authenticate_plain(zap_request& request);
 
-	/*!
+	/**
 	 * Handle a CURVE authentication request from libzmq core
 	 *
-	 * @param user_id store the public key (z85 encoded) as the User-Id.
 	 */
-    	bool authenticate_curve(zap_request& request, std::string &user_id);
+    	bool authenticate_curve(zap_request& request);
 
-    	/*!
+    	/**
 	 * Handle a GSSAPI authentication request from libzmq core
 	 *
 	 */
     	bool authenticate_gssapi(zap_request& request);
 
-    	/*!
+    	/**
      	 * Authentication.
      	 *
      	 */
@@ -153,15 +151,15 @@ private:
     	std::unordered_map<std::string, std::string> 	passwords;      // PLAIN passwords, if loaded
     	std::unordered_set<std::string> 		client_keys;    // Client public keys
     	std::string 				 	domain;			// ZAP domain
-    	bool                        curve_allow_any;      // CURVE allows arbitrary clients
+    	bool 					 	allow_any;      // CURVE allows arbitrary clients
     	bool 					 	terminated;     // Did caller ask us to quit?
     	bool 					 	verbose;        // Verbose logging enabled?
 
-#	if defined(ZMQPP_NO_CONSTEXPR)
-        static const char * const zap_endpoint_;
-#	else
+		/**
+		* This is the endpoint of the ZAP handler.
+		* It is defined in ZeroMQ RFC 27.
+		*/
         constexpr static const char * const zap_endpoint_ = "inproc://zeromq.zap.01";
-#	endif
   
     	// No copy - private and not implemented
     	auth(auth const&) ZMQPP_EXPLICITLY_DELETED;

--- a/src/zmqpp/context.hpp
+++ b/src/zmqpp/context.hpp
@@ -30,7 +30,7 @@
 namespace zmqpp
 {
 
-/*!
+/**
  * The context class represents internal zmq context and io threads.
  *
  * By default the context class will create one thread, however this can be
@@ -48,7 +48,7 @@ class context
 public:
 
 #if (ZMQ_VERSION_MAJOR < 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR < 2))
-	/*!
+	/**
 	 * Initialise the 0mq context.
 	 *
 	 * If only inproc is used then the context may be created with zero threads.
@@ -62,7 +62,7 @@ public:
 	 */
 	context(int const& threads = 1)
 #else
-	/*!
+	/**
 	 * Initialise the 0mq context.
 	 *
 	 * The context is thread safe an may be used anywhere in your application,
@@ -85,7 +85,7 @@ public:
 		}
 	}
 
-	/*!
+	/**
 	 * Closes the 0mq context.
 	 *
 	 * Any blocking calls other than a socket close will return with an error.
@@ -101,7 +101,7 @@ public:
 		}
 	}
 
-	/*!
+	/**
 	 * Move supporting constructor.
 	 *
 	 * Allows zero-copy move semantics to be used with this class.
@@ -114,7 +114,7 @@ public:
 		source._context = nullptr;
 	}
 
-	/*!
+	/**
 	 * Move supporting operator.
 	 *
 	 * Allows zero-copy move semantics to be used with this class.
@@ -127,7 +127,7 @@ public:
 		return *this;
 	}
 
-	/*!
+	/**
 	 * Terminate the current context.
 	 *
 	 * Any blocking calls other than a socket close will return with an error.
@@ -138,7 +138,7 @@ public:
 	void terminate();
 
 #if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
-	/*!
+	/**
 	 * Set the value of an option in the underlaying zmq context.
 	 *
 	 * \param option a valid ::context_option
@@ -146,7 +146,7 @@ public:
 	 */
 	void set(context_option const option, int const value);
 
-	/*!
+	/**
 	 * Get a context option from the underlaying zmq context.
 	 *
 	 * \param option a valid ::context_option
@@ -155,7 +155,7 @@ public:
 	int get(context_option const option);
 #endif
 
-	/*!
+	/**
 	 * Validity checking of the context
 	 *
 	 * Checks if the underlying 0mq context for this instance is valid.
@@ -170,7 +170,7 @@ public:
 		return nullptr != _context;
 	}
 
-	/*!
+	/**
 	 * Access to the raw 0mq context
 	 *
 	 * \return void pointer to the underlying 0mq context.

--- a/src/zmqpp/curve.hpp
+++ b/src/zmqpp/curve.hpp
@@ -20,9 +20,16 @@
 #include <string>
 #include <zmq.h>
 
-namespace zmqpp { namespace curve
+namespace zmqpp {
+/**
+* ZMQ curve facilities.
+*/
+namespace curve
 {
 
+/**
+* A pair of public and private key.
+*/
 struct keypair
 {
 	std::string public_key;

--- a/src/zmqpp/exception.hpp
+++ b/src/zmqpp/exception.hpp
@@ -27,7 +27,7 @@ namespace zmqpp
 
 /** \todo Have a larger variety of exceptions with better state debug information */
 
-/*!
+/**
  * Represents the base zmqpp exception.
  *
  * All zmqpp runtime exceptions are children of this class.
@@ -40,7 +40,7 @@ namespace zmqpp
 class exception : public std::runtime_error
 {
 public:
-	/*!
+	/**
 	 * Standard exception constructor.
 	 *
 	 * \param message a string representing the error message.
@@ -50,7 +50,7 @@ public:
 	{ }
 };
 
-/*!
+/**
  * Represents an attempt to use an invalid object.
  *
  * Objects may be invalid initially or after a shutdown or close.
@@ -90,7 +90,7 @@ public:
     }
   };
 
-/*!
+/**
  * Represents internal zmq errors.
  *
  * Any error response from the zmq bindings will be wrapped in this error.
@@ -100,7 +100,7 @@ public:
 class zmq_internal_exception : public exception
 {
 public:
-	/*!
+	/**
 	 * Uses the zmq functions to pull out error messages and numbers.
 	 */
 	zmq_internal_exception()
@@ -108,7 +108,7 @@ public:
 		, _error(zmq_errno())
 	{ }
 
-	/*!
+	/**
 	 * Retrieve the zmq error number associated with this exception.
 	 * \return zmq error number
 	 */

--- a/src/zmqpp/frame.hpp
+++ b/src/zmqpp/frame.hpp
@@ -23,8 +23,8 @@
 
 namespace zmqpp {
 
-/*!
- * \brief an internal frame wrapper for a single zmq message
+/**
+ * An internal frame wrapper for a single zmq message
  *
  * This frame wrapper consists of a zmq message and meta data it is used
  * by the zmqpp message class to keep track of parts in the internal

--- a/src/zmqpp/message.hpp
+++ b/src/zmqpp/message.hpp
@@ -33,7 +33,7 @@
 namespace zmqpp
 {
 
-/*!
+/**
  * \brief a zmq message with optional multipart support
  *
  * A zmq message is made up of one or more parts which are sent together to
@@ -43,7 +43,7 @@ namespace zmqpp
 class message
 {
 public:
-	/*!
+	/**
 	 * \brief callback to release user allocated data.
 	 *
 	 * The release function will be called on any void* moved part.

--- a/src/zmqpp/poller.hpp
+++ b/src/zmqpp/poller.hpp
@@ -28,10 +28,10 @@ namespace zmqpp
 class socket;
 typedef socket socket_t;
 
-/*!
+/**
  * Polling wrapper.
  *
- * Allows access to polling for any number of zmq sockets or standard sockets.
+ * Allows access to polling for any number of sockets or file descriptors.
  */
 class poller
 {
@@ -47,19 +47,19 @@ public:
         static const short poll_pri;    /*!< Priority input flag.\n Only for file descriptors. See POLLPRI) */
 #endif
 
-	/*!
+	/**
 	 * Construct an empty polling model.
 	 */
 	poller();
 
-	/*!
+	/**
 	 * Cleanup poller.
 	 *
 	 * Any sockets will need to be closed separately.
 	 */
 	~poller();
 
-	/*!
+	/**
 	 * Add a socket to the polling model and set which events to monitor.
 	 *
 	 * \param socket the socket to monitor.
@@ -67,24 +67,24 @@ public:
 	 */
 	void add(socket_t& socket, short const event = poll_in);
 
-	/*!
-	 * Add a standard socket to the polling model and set which events to monitor.
+	/**
+	 * Add a file descriptor to the polling model and set which events to monitor.
 	 *
-	 * \param descriptor the raw socket to monitor (SOCKET under Windows, a file descriptor otherwise).
+	 * \param descriptor the file descriptor to monitor.
 	 * \param event the event flags to monitor.
 	 */
-	void add(raw_socket_t const descriptor, short const event = poll_in | poll_error);
+	void add(int const descriptor, short const event = poll_in | poll_error);
 
-	/*!
+	/**
 	 * Add a zmq_pollitem_t to the poller; Events to monitor are already configured.
 	 * If the zmq_pollitem_t has a null socket pointer it is added to the fdindex,
 	 * otherwise it is added to the socket index.
 	 *
 	 * \param item the pollitem to be added
 	 */
-	void add(zmq_pollitem_t const& item);
+	void add(zmq_pollitem_t item);
 
-	 /*!
+	 /**
 	  * Check if we are monitoring a given socket with this poller.
 	  *
 	  * \param socket the socket to check.
@@ -92,15 +92,15 @@ public:
 	  */
 	 bool has(socket_t const& socket);
 
-	/*!
-	 * Check if we are monitoring a given standard socket with this poller.
+	/**
+	 * Check if we are monitoring a given file descriptor with this poller.
 	 *
-	 * \param descriptor the raw socket to check for.
+	 * \param descriptor the file descriptor to check.
 	 * \return true if it is there.
 	 */
-	 bool has(raw_socket_t const descriptor);
+	bool has(int const descriptor);
 
-	/*!
+	/**
 	 * Check if we are monitoring a given pollitem.
 	 * We assume the pollitem is a socket if it's socket is a non null pointer; otherwise,
 	 * it is considered as a file descriptor.
@@ -108,30 +108,30 @@ public:
 	 * \param item the pollitem to check for
 	 * \return true if it is there.
 	 */
-	bool has(zmq_pollitem_t const& item);
+	bool has(const zmq_pollitem_t &item);
 
-	/*!
+	/**
 	 * Stop monitoring a socket.
 	 *
 	 * \param socket the socket to stop monitoring.
 	 */
 	void remove(socket_t const& socket);
 	
-	/*!
-	 * Stop monitoring a standard socket.
+	/**
+	 * Stop monitoring a file descriptor.
 	 *
-	 * \param descriptor the raw socket to stop monitoring (SOCKET under Windows, a file descriptor otherwise).
+	 * \param descriptor the file descriptor to stop monitoring.
 	 */
-	void remove(raw_socket_t const descriptor);
+	void remove(int const descriptor);
 
-	/*!
+	/**
 	 * Stop monitoring a zmq_pollitem_t
 	 *
 	 * \param item the pollitem to stop monitoring.
 	 */
-	void remove(zmq_pollitem_t const& item);
+	void remove(const zmq_pollitem_t &item);
 
-	/*!
+	/**
 	 * Update the monitored event flags for a given socket.
 	 *
 	 * \param socket the socket to update event flags.
@@ -139,23 +139,23 @@ public:
 	 */
 	void check_for(socket_t const& socket, short const event);
 	
-	/*!
-	 * Update the monitored event flags for a given standard socket.
+	/**
+	 * Update the monitored event flags for a given file descriptor.
 	 *
-	 * \param descriptor the raw socket to update event flags (SOCKET under Windows, a file descriptor otherwise).
+	 * \param descriptor the file descriptor to update event flags.
 	 * \param event the event flags to monitor on the socket.
 	 */
-	void check_for(raw_socket_t const descriptor, short const event);
+	void check_for(int const descriptor, short const event);
 	
-	/*!
+	/**
 	 * Update the monitored event flags for a given zmq_pollitem_t
 	 *
 	 * \param item the item to change event flags for.
 	 * \param event the event flags to monitor on the socket.
 	 */
-	void check_for(zmq_pollitem_t const& item, short const event);
+	void check_for(const zmq_pollitem_t &item, short const event);
 	
-	/*!
+	/**
 	 * Poll for monitored events.
 	 *
 	 * By default this method will block forever or until at least one of the monitored
@@ -168,7 +168,7 @@ public:
 	 */
 	bool poll(long timeout = wait_forever);
 	
-	/*!
+	/**
 	 * Get the event flags triggered for a socket.
 	 *
 	 * \param socket the socket to get triggered event flags for.
@@ -176,53 +176,53 @@ public:
 	 */
 	short events(socket_t const& socket) const;
 	
-	/*!
-	 * Get the event flags triggered for a standard socket.
+	/**
+	 * Get the event flags triggered for a file descriptor.
 	 *
-	 * \param descriptor the raw socket to get triggered event flags for (SOCKET under Windows, a file descriptor otherwise).
+	 * \param descriptor the file descriptor to get triggered event flags for.
 	 * \return the event flags.
 	 */
-	short events(raw_socket_t const descriptor) const;
+	short events(int const descriptor) const;
 	
-	/*!
+	/**
 	 * Get the event flags triggered for a zmq_pollitem_t
 	 *
 	 * \param item the pollitem to get triggered event flags for.
 	 * \return the event flags.
 	 */
-	short events(zmq_pollitem_t const& item) const;
+	short events(const zmq_pollitem_t &item) const;
 
-	/*!
-	 * Check either a standard socket or zmq socket for input events.
+	/**
+	 * Check either a file descriptor or socket for input events.
 	 *
 	 * Templated helper method that calls through to event and checks for a given flag
 	 *
-	 * \param watchable either a standard socket or socket known to the poller.
+	 * \param watchable either a file descriptor or socket known to the poller.
 	 * \return true if there is input.
 	 */
 	template<typename Watched>
 	bool has_input(Watched const& watchable) const { return (events(watchable) & poll_in) != 0; }
 
-	/*!
-	 * Check either a standard socket or zmq socket for output events.
+	/**
+	 * Check either a file descriptor or socket for output events.
 	 *
 	 * Templated helper method that calls through to event and checks for a given flag
 	 *
-	 * \param watchable either a standard socket or zmq socket known to the poller.
+	 * \param watchable either a file descriptor or socket known to the poller.
 	 * \return true if there is output.
 	 */
 	template<typename Watched>
 	bool has_output(Watched const& watchable) const { return (events(watchable) & poll_out) != 0; }
 
-	/*!
-	 * Check a standard socket (file descriptor or SOCKET).
+	/**
+	 * Check a file descriptor.
 	 *
 	 * Templated helper method that calls through to event and checks for a given flag
 	 *
 	 * Technically this template works for sockets as well but the error flag is never set for
 	 * sockets so I have no idea why someone would call it.
 	 *
-	 * \param watchable a standard socket known to the poller.
+	 * \param watchable a file descriptor know to the poller.
 	 * \return true if there is an error.
 	 */
 	template<typename Watched>
@@ -231,7 +231,7 @@ public:
 private:
 	std::vector<zmq_pollitem_t> _items;
 	std::unordered_map<void *, size_t> _index;
-	std::unordered_map<raw_socket_t, size_t> _fdindex;
+	std::unordered_map<int, size_t> _fdindex;
 
 	void reindex(size_t const index);
 };

--- a/src/zmqpp/reactor.hpp
+++ b/src/zmqpp/reactor.hpp
@@ -23,7 +23,7 @@ namespace zmqpp
     class socket;
     typedef socket socket_t;
 
-    /*!
+    /**
      * Reactor object that helps to manage multiple socket by calling a user-defined handler for each socket
      * when a watched event occurs.
      *
@@ -34,19 +34,19 @@ namespace zmqpp
     public:
         typedef std::function<void (void) > Callable;
         typedef std::pair<zmq_pollitem_t, Callable> PollItemCallablePair;
-        /*!
+        /**
          * Construct an empty polling model.
          */
         reactor();
 
-        /*!
+        /**
          * Cleanup reactor.
          *
          * Any sockets will need to be closed separately.
          */
         ~reactor();
 	
-        /*!
+        /**
          * Add a socket to the reactor, providing a handler that will be called when the monitored events occur.
          *
          * \param socket the socket to monitor.
@@ -55,16 +55,16 @@ namespace zmqpp
          */
         void add(socket_t& socket, Callable callable, short const event = poller::poll_in);
 
-        /*!
-         * Add a standard socket to the reactor, providing a handler that will be called when the monitored events occur.
+        /**
+         * Add a file descriptor to the reactor, providing a handler that will be called when the monitored events occur.
          *
-         * \param descriptor the standard socket to monitor (SOCKET under Windows, a file descriptor otherwise).
+         * \param descriptor the file descriptor to monitor.
          * \param callable the function that will be called by the reactor when a registered event occurs on fd.
          * \param event the event flags to monitor.
          */
-        void add(raw_socket_t const descriptor, Callable callable, short const event = poller::poll_in | poller::poll_error);
+        void add(int const descriptor, Callable callable, short const event = poller::poll_in | poller::poll_error);
 
-        /*!
+        /**
          * Check if we are monitoring a given socket with this reactor.
          *
          * \param socket the socket to check.
@@ -72,29 +72,29 @@ namespace zmqpp
          */
         bool has(socket_t const& socket);
 
-        /*!
-         * Check if we are monitoring a given standard socket with this reactor.
+        /**
+         * Check if we are monitoring a given file descriptor with this reactor.
          *
-         * \param descriptor the raw socket to check (SOCKET under Windows, a file descriptor otherwise).
+         * \param descriptor the file descriptor to check.
          * \return true if it is there.
          */
-        bool has(raw_socket_t const descriptor);
+        bool has(int const descriptor);
 
-        /*!
+        /**
          * Stop monitoring a socket.
          *
          * \param socket the socket to stop monitoring.
          */
         void remove(socket_t const& socket);
 
-        /*!
-         * Stop monitoring a standard socket.
+        /**
+         * Stop monitoring a file descriptor.
          *
-         * \param descriptor the standard socket to stop monitoring.
+         * \param descriptor the file descriptor to stop monitoring.
          */
-        void remove(raw_socket_t const descriptor);
+        void remove(int const descriptor);
 
-        /*!
+        /**
          * Update the monitored event flags for a given socket.
          *
          * \param socket the socket to update event flags.
@@ -102,15 +102,15 @@ namespace zmqpp
          */
         void check_for(socket_t const& socket, short const event);
 
-        /*!
-         * Update the monitored event flags for a given standard socket.
+        /**
+         * Update the monitored event flags for a given file descriptor.
          *
-         * \param descriptor the raw socket to update event flags (SOCKET under Windows, a file descriptor otherwise).
+         * \param descriptor the file descriptor to update event flags.
          * \param event the event flags to monitor on the socket.
          */
-        void check_for(raw_socket_t const descriptor, short const event);
+        void check_for(int const descriptor, short const event);
 
-        /*!
+        /**
          * Poll for monitored events and call associated handler when needed.
          *
          * By default this method will block forever or until at least one of the monitored
@@ -123,7 +123,7 @@ namespace zmqpp
          */
         bool poll(long timeout = poller::wait_forever);
 
-        /*!
+        /**
          * Get the event flags triggered for a socket.
          *
          * \param socket the socket to get triggered event flags for.
@@ -131,13 +131,13 @@ namespace zmqpp
          */
         short events(socket_t const& socket) const;
 
-        /*!
-         * Get the event flags triggered for a standard socket.
+        /**
+         * Get the event flags triggered for a file descriptor.
          *
-         * \param descriptor the raw socket to get triggered event flags for (SOCKET under Windows, a file descriptor otherwise).
+         * \param descriptor the file descriptor to get triggered event flags for.
          * \return the event flags.
          */
-        short events(raw_socket_t const descriptor) const;
+        short events(int const descriptor) const;
 
 
         /**
@@ -158,7 +158,7 @@ namespace zmqpp
     private:
         std::vector<PollItemCallablePair> items_;
         std::vector<const socket_t *> sockRemoveLater_;
-        std::vector<raw_socket_t> fdRemoveLater_;
+        std::vector<int> fdRemoveLater_;
       
       /**
        * Flush the fdRemoveLater_ and sockRemoveLater_ vector, effectively removing

--- a/src/zmqpp/socket.hpp
+++ b/src/zmqpp/socket.hpp
@@ -58,7 +58,7 @@ namespace event
 }
 #endif
 
-/*!
+/**
  * The socket class represents the zmq sockets.
  *
  * A socket can be bound and/or connected to as many endpoints as required
@@ -86,7 +86,7 @@ public:
 	static const int send_label;				/*!< /brief this message part is an internal zmq label */
 #endif
 
-	/*!
+	/**
 	 * Create a socket for a given type.
 	 *
 	 * \param context the zmq context under which the socket will live
@@ -94,12 +94,12 @@ public:
 	 */
 	socket(context_t const& context, socket_type const type);
 
-	/*!
+	/**
 	 * This will close any socket still open before returning
 	 */
 	~socket();
 
-	/*!
+	/**
 	 * Get the type of the socket, this works on zmqpp types and not the zmq internal types.
 	 * Use the socket::get method if you wish to intergoate the zmq internal ones.
 	 *
@@ -107,7 +107,7 @@ public:
 	 */
 	socket_type type() const { return _type; }
 
-	/*!
+	/**
 	 * Asynchronously binds to an endpoint.
 	 *
 	 * \param endpoint the zmq endpoint to bind to
@@ -115,7 +115,7 @@ public:
 	void bind(endpoint_t const& endpoint);
 
 #if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
-	/*!
+	/**
 	 * Unbinds from a previously bound endpoint.
 	 *
 	 * \param endpoint the zmq endpoint to bind to
@@ -123,7 +123,7 @@ public:
 	void unbind(endpoint_t const& endpoint);
 #endif
 
-	/*!
+	/**
 	 * Asynchronously connects to an endpoint.
 	 * If the endpoint is not inproc then zmq will happily keep trying
 	 * to connect until there is something there.
@@ -135,7 +135,7 @@ public:
 	 */
 	void connect(endpoint_t const& endpoint);
 
-	/*!
+	/**
 	 * Asynchronously connects to multiple endpoints.
 	 * If the endpoint is not inproc then zmq will happily keep trying
 	 * to connect until there is something there.
@@ -158,7 +158,7 @@ public:
 	}
 
 
-	/*!
+	/**
 	 * Disconnects a previously connected endpoint.
 	 *
 	 * \param endpoint the zmq endpoint to disconnect from
@@ -166,7 +166,7 @@ public:
 #if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 	void disconnect(endpoint_t const& endpoint);
 
-	/*!
+	/**
 	 * Disconnects from multiple previously connected endpoints.
 	 *
 	 * This is a helper function that wraps the single item disconnect in a loop
@@ -184,13 +184,13 @@ public:
 	}
 #endif
 
-	/*!
+	/**
 	 * Closes the internal zmq socket and marks this instance
 	 * as invalid.
 	 */
 	void close();
 
-	/*!
+	/**
 	 * Sends the message over the connection, this may be a multipart message.
 	 *
 	 * If dont_block is true and we are unable to add a new message then this
@@ -202,7 +202,7 @@ public:
 	 */
 	bool send(message_t& message, bool const dont_block = false);
 
-	/*!
+	/**
 	 * Gets a message from the connection, this may be a multipart message.
 	 *
 	 * If dont_block is true and we are unable to get a message then this
@@ -214,7 +214,7 @@ public:
 	 */
 	bool receive(message_t& message, bool const dont_block = false);
 
-	/*!
+	/**
 	 * Sends the byte data held by the string as the next message part.
 	 *
 	 * If the socket::DONT_WAIT flag and we are unable to add a new message to
@@ -226,7 +226,7 @@ public:
 	 */
 	bool send(std::string const& string, int const flags = normal);
 
-	/*!
+	/**
 	 * If there is a message ready then get the next part as a string
 	 *
 	 * If the socket::DONT_WAIT flag and there is no message ready to receive
@@ -251,7 +251,7 @@ public:
 	bool send(signal sig, bool dont_block = false);
 
 
-    	/*!
+    	/**
 	 * If there is a message ready then we read a signal from it.
 	 *
 	 * If dont_block is true and we are unable to send the signal then this
@@ -263,7 +263,7 @@ public:
 	 */
 	bool receive(signal &sig, bool dont_block = false);
 
-	/*!
+	/**
 	 * Sends the byte data pointed to by buffer as the next part of the message.
 	 *
 	 * If the socket::DONT_WAIT flag and we are unable to add a new message to
@@ -276,7 +276,7 @@ public:
 	 */
 	bool send_raw(char const* buffer, size_t const length, int const flags = normal);
 
-	/*!
+	/**
 	 * \warning If the buffer is not large enough for the message part then the
 	 *       data will be truncated. The rest of the part is lost forever.
 	 *
@@ -293,7 +293,7 @@ public:
 	 */
 	bool receive_raw(char* buffer, size_t& length, int const flags = normal);
 
-	/*!
+	/**
 	 *
 	 * Subscribe to a topic
 	 *
@@ -308,7 +308,7 @@ public:
 	 */
 	void subscribe(std::string const& topic);
 
-	/*!
+	/**
 	 * Subscribe to a topic
 	 *
 	 * Helper function that is equivalent of a loop calling
@@ -335,7 +335,7 @@ public:
 		}
 	}
 
-	/*!
+	/**
 	 * Unsubscribe from a topic
 	 *
 	 * Helper function that is equivalent of calling
@@ -349,7 +349,7 @@ public:
 	 */
 	void unsubscribe(std::string const& topic);
 
-	/*!
+	/**
 	 * Unsubscribe from a topic
 	 *
 	 * Helper function that is equivalent of a loop calling
@@ -376,7 +376,7 @@ public:
 		}
 	}
 
-	/*!
+	/**
 	 * If the last receive part call to the socket resulted
 	 * in a label or a non-terminating part of a multipart
 	 * message this will return true.
@@ -385,7 +385,7 @@ public:
 	 */
 	bool has_more_parts() const;
 
-	/*!
+	/**
 	 * Set the value of an option in the underlaying zmq socket.
 	 *
 	 * \param option a valid ::socket_option
@@ -393,7 +393,7 @@ public:
 	 */
 	void set(socket_option const option, int const value);
 
-	/*!
+	/**
 	 * Set the value of an option in the underlaying zmq socket.
 	 *
 	 * \since 2.0.0 (built against 0mq version 3.1.x or later)
@@ -403,7 +403,7 @@ public:
 	 */
 	void set(socket_option const option, bool const value);
 
-	/*!
+	/**
 	 * Set the value of an option in the underlaying zmq socket.
 	 *
 	 * \param option a valid ::socket_option
@@ -411,7 +411,7 @@ public:
 	 */
 	void set(socket_option const option, uint64_t const value);
 
-	/*!
+	/**
 	 * Set the value of an option in the underlaying zmq socket.
 	 *
 	 * \param option a valid ::socket_option
@@ -419,7 +419,7 @@ public:
 	 */
 	void set(socket_option const option, int64_t const value);
 
-	/*!
+	/**
 	 * Set the value of an option in the underlaying zmq socket.
 	 *
 	 * \param option a valid ::socket_option
@@ -428,7 +428,7 @@ public:
 	 */
 	void set(socket_option const option, char const* value, size_t const length);
 
-	/*!
+	/**
 	 * Set the value of an option in the underlaying zmq socket.
 	 *
 	 * \param option a valid ::socket_option
@@ -436,7 +436,7 @@ public:
 	 */
 	inline void set(socket_option const option, char const* value) { set(option, value, strlen(value)); }
 
-	/*!
+	/**
 	 * Set the value of an option in the underlaying zmq socket.
 	 *
 	 * \param option a valid ::socket_option
@@ -444,7 +444,7 @@ public:
 	 */
 	inline void set(socket_option const option, std::string const value) { set(option, value.c_str(), value.length()); }
 
-	/*!
+	/**
 	 * Get a socket option from the underlaying zmq socket.
 	 *
 	 * \param option a valid ::socket_option
@@ -452,7 +452,7 @@ public:
 	 */
 	void get(socket_option const option, int& value) const;
 
-	/*!
+	/**
 	 * Get a socket option from the underlaying zmq socket.
 	 *
 	 * \param option a valid ::socket_option
@@ -460,7 +460,7 @@ public:
 	 */
 	void get(socket_option const option, bool& value) const;
 
-	/*!
+	/**
 	 * Get a socket option from the underlaying zmq socket.
 	 *
 	 * \param option a valid ::socket_option
@@ -468,7 +468,7 @@ public:
 	 */
 	void get(socket_option const option, uint64_t& value) const;
 
-	/*!
+	/**
 	 * Get a socket option from the underlaying zmq socket.
 	 *
 	 * \param option a valid ::socket_option
@@ -476,7 +476,7 @@ public:
 	 */
 	void get(socket_option const option, int64_t& value) const;
 
-	/*!
+	/**
 	 * Get a socket option from the underlaying zmq socket.
 	 *
 	 * \param option a valid ::socket_option
@@ -484,7 +484,7 @@ public:
 	 */
 	void get(socket_option const option, std::string& value) const;
 
-	/*!
+	/**
 	 * For those that don't want to get into a referenced value this templated method
 	 * will return the value instead.
 	 *
@@ -500,7 +500,7 @@ public:
 	}
 
 #if (ZMQ_VERSION_MAJOR >= 4)
-	/*!
+	/**
 	 * Attach a monitor to this socket that will send events over inproc to the
 	 * specified endpoint. The monitor will bind on the endpoint given and will
 	 * be of type PAIR but not read from the stream.
@@ -511,7 +511,7 @@ public:
 	void monitor(endpoint_t const monitor_endpoint, int events_required);
 #endif
 
-	/*!
+	/**
 	 * Wait on signal, this is useful to coordinate thread.
 	 * Block until a signal is received, and returns the received signal.
 	 *
@@ -520,7 +520,7 @@ public:
 	 */
 	signal wait();
 
-	/*!
+	/**
 	 * Move constructor
 	 *
 	 * Moves the internals of source to this object, there is no guarantee
@@ -532,7 +532,7 @@ public:
 	 */
 	socket(socket&& source) NOEXCEPT;
 
-	/*!
+	/**
 	 * Move operator
 	 *
 	 * Moves the internals of source to this object, there is no guarantee
@@ -545,7 +545,7 @@ public:
 	 */
 	socket& operator=(socket&& source) NOEXCEPT;
 
-	/*!
+	/**
 	 * Check the socket is still valid
 	 *
 	 * This tests the internal state of the socket.
@@ -556,7 +556,7 @@ public:
 	 */
 	operator bool() const;
 
-	/*!
+	/**
 	 * Access to the raw 0mq context
 	 *
 	 * \return void pointer to the underlying 0mq socket

--- a/src/zmqpp/z85.hpp
+++ b/src/zmqpp/z85.hpp
@@ -15,6 +15,9 @@
 namespace zmqpp
 {
 #if (ZMQ_VERSION_MAJOR >= 4)
+  /**
+  * Provide z85 encoding and decoding facilities.
+  */
   namespace z85
   {
     /**

--- a/src/zmqpp/zap_request.hpp
+++ b/src/zmqpp/zap_request.hpp
@@ -25,82 +25,80 @@
 namespace zmqpp
 {
 
-/*!
+/**
  * A class for working with ZAP requests and replies.
  * Used in auth to simplify working with RFC 27 messages.
  *
  */
 class zap_request {
 public:
-    /*!
+    /**
      * Receive a ZAP valid request from the handler socket
      */
     zap_request(socket& handler, bool logging);
     
-    /*! 
+    /** 
      * Send a ZAP reply to the handler socket
      */
-    void reply(const std::string &status_code, const std::string &status_text,
-            const std::string &user_id);
+    void reply (std::string status_code, std::string status_text);
 
-    /*! 
+    /** 
      * Get Version
      */
     const std::string & get_version() const {
         return version;
     }
 
-    /*! 
+    /** 
      * Get Domain
      */
     const std::string & get_domain() const {
         return domain;
     }
 
-    /*! 
+    /** 
      * Get Address
      */
     const std::string & get_address() const {
         return address;
     }
 
-    /*! 
+    /** 
      * Get Identity
      */
     const std::string & get_identity() const {
         return identity;
     }
 
-    /*! 
+    /** 
      * Get Security Mechanism
      */
     const std::string & get_mechanism() const {
         return mechanism;
     }
 
-    /*! 
+    /** 
      * Get username for PLAIN security mechanism
      */
     const std::string & get_username() const {
         return username;
     }
 
-    /*! 
+    /** 
      * Get password for PLAIN security mechanism
      */
     const std::string & get_password() const {
         return password;
     }
 
-    /*! 
-     * Get client_key for CURVE security mechanism.
-     * The key is z85 encoded.
+    /** 
+     * Get client_key for CURVE security mechanism
      */
     const std::string & get_client_key() const {
         return client_key;
     }
 
-    /*! 
+    /** 
      * Get principal for GSSAPI security mechanism
      */
     const std::string & get_principal() const {


### PR DESCRIPTION
This adds a mainpage to doxygen documentation (i'll just go ahead and implement #69 when this is merged).

I also bump the version to 4.1.2 so I can tag a release, as promised in #118.