### PR TITLE
Problem: No Copy behavior could be improved.

### DIFF
--- a/src/tests/test_message.cpp
+++ b/src/tests/test_message.cpp
@@ -546,6 +546,8 @@ BOOST_AUTO_TEST_CASE( add_nocopy )
     void* data = malloc(15);
     memcpy(data, "a_longer_hello", 14);
 
+    //msg.add_nocopy(const_data, 5); should trigger static assert.
+
     msg.add_nocopy_const(const_data, 5);
     msg.add_nocopy(data, 14);
 

--- a/src/zmqpp/compatibility.hpp
+++ b/src/zmqpp/compatibility.hpp
@@ -100,8 +100,13 @@
 #define ZMQPP_EXPLICITLY_DELETED = delete
 #endif
 
-#if __cplusplus >= 201300  // this worked in g++4.9
+#if __cplusplus >= 201300  // c++14 version. This number worked
+                           // on g++ 4.9 when compiling with -std=c++14
 #define ZMQPP_DEPRECATED(reason) [[deprecated(#reason)]]
+#elif __GNUC__
+#define ZMQPP_DEPRECATED(reason) __attribute__ ((deprecated))
+#elif defined(_MSC_VER)
+#define ZMQPP_DEPRECATED(reason) __declspec(deprecated(#reason))
 #else
 #define ZMQPP_DEPRECATED(reason)
 #endif

--- a/src/zmqpp/compatibility.hpp
+++ b/src/zmqpp/compatibility.hpp
@@ -100,6 +100,12 @@
 #define ZMQPP_EXPLICITLY_DELETED = delete
 #endif
 
+#if __cplusplus >= 201300  // this worked in g++4.9
+#define ZMQPP_DEPRECATED(reason) [[deprecated(#reason)]]
+#else
+#define ZMQPP_DEPRECATED(reason)
+#endif
+
 #ifndef NOEXCEPT
 #define NOEXCEPT noexcept
 #endif

--- a/src/zmqpp/message.hpp
+++ b/src/zmqpp/message.hpp
@@ -163,9 +163,78 @@ public:
 	// this data. It must remain as valid for at least the lifetime of the
 	// 0mq message, recommended only with const data.
 	template<typename Type>
+	ZMQPP_DEPRECATED("Use add_nocopy() or add_nocopy_const() instead.")
 	void add_const(Type *part, size_t const data_size)
 	{
 		_parts.push_back( frame( part, data_size, nullptr, nullptr ) );
+	}
+
+	/**
+	 * Add a no-copy frame.
+	 *
+	 * This means that neither zmqpp nor libzmq will make a copy of the
+	 * data. The pointed-to data must remain valid for the lifetime of
+	 * the underlying zmq_msg_t. Note that you cannot always know about
+	 * this lifetime, so be careful.
+	 *
+	 * @param part The pointed-to data that will be send in the message.
+	 * @param data_size The number of byte pointed-to by "part".
+	 * @param ffn The free function called by libzmq when it doesn't need
+	 * your buffer anymore. It defaults to nullptr, meaning your data
+	 * will not be freed.
+	 * @param hint A hint to help your free function do its job.
+	 *
+	 * @note This is similar to what `move()` does. While `move()` provide a safe
+	 * (wrt to type) deleter (at the cost of 1 memory allocation) add_nocopy
+	 * let you pass the low-level callback that libzmq will invoke.
+	 *
+	 * @note The free function must be thread-safe as it can be invoke from
+	 * any libzmq's context threads.
+	 *
+	 * @see add_nocopy_const
+	 * @see move
+	 */
+	template<typename Type>
+	void add_nocopy(Type *part, size_t const data_size,
+					zmq_free_fn *ffn = nullptr, void *hint = nullptr)
+	{
+		static_assert(!std::is_const<Type *>::value,
+					  "Data part must not be const. Use add_nocopy_const() instead (and read its documentation)");
+		_parts.push_back(frame(part, data_size, ffn, hint));
+	}
+
+	/**
+	 * Add a no-copy frame where pointed-to data are const.
+	 *
+	 * This means that neither zmqpp nor libzmq will make a copy of the
+	 * data. The pointed-to data must remain valid for the lifetime of
+	 * the underlying zmq_msg_t. Note that you cannot always know about
+	 * this lifetime, so be careful.
+	 *
+	 * @warning About constness: The library will cast away constness from
+	 * your pointer. However, it promises that both libzmq and zmqpp will
+	 * not alter the pointed-to data. *YOU* must however be careful: zmqpp or libzmq
+	 * will happily return a non-const pointer to your data. It's your responsibility
+	 * to not modify it.
+	 *
+	 * @param part The pointed-to data that will be send in the message.
+	 * @param data_size The number of byte pointed-to by "part".
+	 * @param ffn The free function called by libzmq when it doesn't need
+	 * your buffer anymore. It defaults to nullptr, meaning your data
+	 * will not be freed.
+	 * @param hint A hint to help your free function do its job.
+	 *
+	 * @note The free function must be thread-safe as it can be invoke from
+	 * any libzmq's context threads.
+	 *
+	 * @see add_nocopy
+	 */
+	template<typename Type>
+	void add_nocopy_const(const Type *part, size_t const data_size,
+				   zmq_free_fn *ffn = nullptr, void *hint = nullptr)
+	{
+		add_nocopy(const_cast<typename std::remove_const<Type *>::type>(part),
+				   data_size, ffn, hint);
 	}
 
 	// Stream reader style

--- a/src/zmqpp/message.hpp
+++ b/src/zmqpp/message.hpp
@@ -198,8 +198,8 @@ public:
 	void add_nocopy(Type *part, size_t const data_size,
 					zmq_free_fn *ffn = nullptr, void *hint = nullptr)
 	{
-		static_assert(!std::is_const<Type *>::value,
-					  "Data part must not be const. Use add_nocopy_const() instead (and read its documentation)");
+		static_assert(!std::is_const<Type>::value,
+                      "Data part must not be const. Use add_nocopy_const() instead (and read its documentation)");
 		_parts.push_back(frame(part, data_size, ffn, hint));
 	}
 


### PR DESCRIPTION
See #123. The NoCopy mechanism was available through `move()`
and `add_const()`.

This patch adds `add_nocopy()` and `add_nocopy_const()`.
`add_nocopy()` is similar to `move()` but does not perform
memory allocation to create a type safe deleter. Instead the
user provide his own libzmq-level deleter. Reject pointer to
const data.

`add_nocopy_const()` let the user pass a pointer to const data
and perform the cast internally. This function is to make it
very clear that the user pass const data and that he must
therefore be careful not modifying them later.

Deprecate `add_const()` in favor of the new functions (see #123
for more info).