### PR TITLE
Added socket option for router_handover

### DIFF
--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -506,6 +506,9 @@ void socket::set(socket_option const option, bool const value)
 	case socket_option::request_relaxed:
 	case socket_option::router_raw:
 #endif
+#if (ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR >= 4 && ZMQ_VERSION_MINOR >= 1)
+	case socket_option::router_handover:
+#endif
 	{
 		int ivalue = value ? 1 : 0;
 		if (0 != zmq_setsockopt(_socket, static_cast<int>(option), &ivalue, sizeof(ivalue)))


### PR DESCRIPTION
I tried setting `socket.set(zmqpp::socket_option::router_handover, true);` but was getting a runtime exception that it could not be done.

```
terminate called after throwing an instance of 'zmqpp::exception'
  what():  attempting to set a non boolean option with a boolean value
Aborted (core dumped)
```

I added the above snippet so that now zmqpp correctly handles this call.

I tested the solution manually and it works as intended. Also, I tried to write a unit test, but I could not get my hand around all those macros -- I am rather new to C++. 

I also considered writing a corresponding fix for the get option, but [according to the docs](http://zeromq.github.io/zmqpp/namespacezmqpp.html#aea04ff9a72915eb7fc621a023f3e8843), this should be a _set only_ option.