### PR TITLE
Improve exception handling

### DIFF
--- a/src/zmqpp/actor.cpp
+++ b/src/zmqpp/actor.cpp
@@ -7,10 +7,10 @@
  * Copyright (c) 2011-2015 Contributors as noted in the AUTHORS file.
  */
 
-/* 
+/*
  * File:   actor.cpp
  * Author: xaqq
- * 
+ *
  * Created on May 20, 2014, 10:51 PM
  */
 
@@ -29,31 +29,31 @@ zmqpp::context zmqpp::actor::actor_pipe_ctx_;
 namespace zmqpp
 {
 
-    actor::actor(ActorStartRoutine routine) :
-    parent_pipe_(nullptr),
-    child_pipe_(nullptr),
-    stopped_(false)
+  actor::actor(ActorStartRoutine routine)
+      : parent_pipe_(nullptr)
+      , child_pipe_(nullptr)
+      , stopped_(false)
+  {
+    std::string pipe_endpoint;
+
+    parent_pipe_  = new socket(actor_pipe_ctx_, socket_type::pair);
+    pipe_endpoint = bind_parent();
+
+    child_pipe_ = new socket(actor_pipe_ctx_, socket_type::pair);
+    child_pipe_->connect(pipe_endpoint);
+
+    std::thread t(&actor::start_routine, this, child_pipe_, routine);
+    t.detach();
+
+    signal sig;
+    sig = parent_pipe_->wait();
+    assert(sig == signal::ok || sig == signal::ko);
+    if (sig == signal::ko)
     {
-      std::string pipe_endpoint;
-
-      parent_pipe_ = new socket(actor_pipe_ctx_, socket_type::pair);
-      pipe_endpoint = bind_parent();
-
-        child_pipe_ = new socket(actor_pipe_ctx_, socket_type::pair);
-        child_pipe_->connect(pipe_endpoint);
-
-        std::thread t(&actor::start_routine, this, child_pipe_, routine);
-        t.detach();
-
-        signal sig;
-        sig = parent_pipe_->wait();
-        assert(sig == signal::ok || sig == signal::ko);
-        if (sig == signal::ko)
-        {
-            delete parent_pipe_;
-            throw actor_initialization_exception();
-        }
+      delete parent_pipe_;
+      throw actor_initialization_exception();
     }
+  }
 
   actor::actor(actor &&o)
   {
@@ -62,79 +62,81 @@ namespace zmqpp
 
   actor &actor::operator=(actor &&o)
   {
-    parent_pipe_ = o.parent_pipe_;
-    stopped_ = o.stopped_;
-    retval_ = o.retval_;
+    parent_pipe_   = o.parent_pipe_;
+    stopped_       = o.stopped_;
+    retval_        = o.retval_;
     o.parent_pipe_ = nullptr;
 
     return *this;
   }
 
-    actor::~actor()
+  actor::~actor()
+  {
+    stop(true);
+    delete parent_pipe_;
+  }
+
+  bool actor::stop(bool block /* = false */)
+  {
+    if (!parent_pipe_)
+      return false;
+
+    parent_pipe_->send(signal::stop, true);
+    if (!block)
     {
-        stop(true);
-        delete parent_pipe_;
+      return true;
     }
-
-    bool actor::stop(bool block /* = false */)
+    else
     {
-        if (!parent_pipe_)
-	  return false;
-      
-        parent_pipe_->send(signal::stop, true);
-        if (!block)
-        {
-            return true;
-        }
-        else
-        {
-            if (stopped_)
-                return retval_;
+      if (stopped_)
+        return retval_;
 
-            // wait for a response from the child. Either it successfully shutdown, or not.
-            signal sig = parent_pipe_->wait();
-            stopped_ = true;
-            assert(sig == signal::ok || sig == signal::ko);
-            return (retval_ = (sig == signal::ok));
-        }
+      // wait for a response from the child. Either it successfully shutdown, or
+      // not.
+      signal sig = parent_pipe_->wait();
+      stopped_ = true;
+      assert(sig == signal::ok || sig == signal::ko);
+      return (retval_ = (sig == signal::ok));
     }
+  }
 
-    void actor::start_routine(socket *child_pipe, ActorStartRoutine routine)
+  void actor::start_routine(socket *child_pipe, ActorStartRoutine routine)
+  {
+    if (routine(child_pipe))
+      child_pipe->send(signal::ok);
+    else
+      child_pipe->send(signal::ko);
+    delete child_pipe;
+  }
+
+  socket *actor::pipe()
+  {
+    return parent_pipe_;
+  }
+
+  const socket *actor::pipe() const
+  {
+    return parent_pipe_;
+  }
+
+  std::string actor::bind_parent()
+  {
+    std::string base_endpoint =
+        "inproc://zmqpp::actor::" +
+        std::to_string(reinterpret_cast<ptrdiff_t>(this));
+
+    for (;;)
     {
-        if (routine(child_pipe))
-            child_pipe->send(signal::ok);
-        else
-            child_pipe->send(signal::ko);
-        delete child_pipe;
+      try
+      {
+        std::string endpoint = base_endpoint + std::to_string(std::rand());
+        parent_pipe_->bind(endpoint);
+        return endpoint;
+      }
+      catch (zmq_internal_exception const &)
+      {
+        // endpoint already taken.
+      }
     }
-
-    socket* actor::pipe()
-    {
-        return parent_pipe_;
-    }
-
-    const socket* actor::pipe() const
-    {
-        return parent_pipe_;
-    }
-
-    std::string actor::bind_parent()
-    {
-        std::string base_endpoint = "inproc://zmqpp::actor::" + std::to_string(reinterpret_cast<ptrdiff_t> (this));
-
-        for (;;)
-        {
-            try
-            {
-                std::string endpoint = base_endpoint + std::to_string(std::rand());
-                parent_pipe_->bind(endpoint);
-                return endpoint;
-            }
-            catch (zmq_internal_exception const&)
-            {
-                // endpoint already taken.
-            }
-        }
-    }
-
+  }
 }

--- a/src/zmqpp/actor.hpp
+++ b/src/zmqpp/actor.hpp
@@ -11,136 +11,151 @@
 
 #include <thread>
 #include <functional>
+#include <mutex>
 #include "socket.hpp"
 
 namespace zmqpp
 {
 
+  /**
+   * An actor is a thread with a pair socket connected to its parent.
+   * It aims to be similar to CMZQ's zactor.
+   *
+   * From the parent thread, instancing an actor will spawn a new thread, and
+   * install
+   * a pipe between those two threads.
+   *	1. The parent's end of the pipe can be retrieved by calling pipe() on
+   *       the actor.
+   *	2. The child's end is passed as a parameter to the routine executed in
+   *       the child's thread.
+   *
+   * You don't have to manage the 2 PAIR sockets. The parent's one will be
+   * destroyed when the actor dies, and the child's end is taken care
+   * of when the user routine ends.
+   *
+   * @note
+   *  About user-supplied routine return value:
+   *	1. If the supplied routine returns true, signal::ok will be send to the
+   *       parent.
+   *	2. If it returns false, signal::ko is send instead.
+   *
+   * @note There is a simple protocol between actor and parent to avoid
+   *       synchronization problem:
+   *	1. The actor constructor expect to receive either signal::ok or
+   *       signal::ko before it returns.
+   *	2. When sending signal::stop (actor destruction or by calling stop()),
+   *       we expect a response: (either signal::ko or signal::ok).
+   *       This response is used to determine if stop() will return true or
+   *       false when in blocking mode.
+   */
+  class actor
+  {
+  public:
     /**
-     * An actor is a thread with a pair socket connected to its parent.
-     * It aims to be similar to CMZQ's zactor.
-     * 
-     * From the parent thread, instancing an actor will spawn a new thread, and install
-     * a pipe between those two threads.
-     *	1. The parent's end of the pipe can be retrieved by calling pipe() on the actor.
-     *	2. The child's end is passed as a parameter to the routine executed in the child's thread.
-     * 
-     * You don't have to manage the 2 PAIR sockets. The parent's one will be destroyed
-     * when the actor dies, and the child's end is taken care of when the user routine ends.
-     * 
-     * @note
-     *  About user-supplied routine return value:
-     *	1. If the supplied routine returns true, signal::ok will be send to the parent.
-     *	2. If it returns false, signal::ko is send instead.
-     * 
-     * @note
-     * There is a simple protocol between actor and parent to avoid synchronization problem:
-     *	1. The actor constructor expect to receive either signal::ok or signal::ko before it returns.
-     *	2. When sending signal::stop (actor destruction or by calling stop()), we expect a response:
-     *	    (either signal::ko or signal::ok). This response is used to determine if stop() will return
-     *	    true or false when in blocking mode.
+     * The user defined function type.
      */
-    class actor
-    {
-    public:
-	/**
-	 * The user defined function type.
-	 */
-	typedef std::function<bool (socket *pipe) > ActorStartRoutine;
+    typedef std::function<bool(socket *pipe)> ActorStartRoutine;
 
-	/**
-	 * Create a new actor. This will effectively create a new thread and runs the user supplied routine.
-	 * The constructor expect a signal from the routine before returning.
-	 * 
-	 * Expect to receive either signal::ko or signal::ok before returning.
-	 * If it receives signal::ko, it will throw. 
-	 * @param routine to be executed.
-	 */
-	actor(ActorStartRoutine routine);
-	actor(const actor&) = delete;
+    /**
+     * Create a new actor. This will effectively create a new thread and runs
+     * the user supplied routine.
+     * The constructor expect a signal from the routine before returning.
+     *
+     * Expect to receive either signal::ko or signal::ok before returning.
+     * If it receives signal::ko, it will throw.
+     * @param routine to be executed.
+     */
+    actor(ActorStartRoutine routine);
+    actor(const actor &) = delete;
 
-      /**
-       * Move constructor. The other actor will not be usable anymore.
-       * Its pipe() method shall return null, and stop() will do nothing.
-       */
-      actor(actor &&o);
+    /**
+     * Move constructor. The other actor will not be usable anymore.
+     * Its pipe() method shall return null, and stop() will do nothing.
+     */
+    actor(actor &&o);
 
-      /**
-       * Move-assignment operator. 
-       * @see move constructor.
-       */
-      actor &operator=(actor &&o);
+    /**
+     * Move-assignment operator.
+     * @see move constructor.
+     */
+    actor &operator=(actor &&o);
 
-	virtual ~actor();
+    virtual ~actor();
 
-	/**
-	 * @return pointer to the parent's end of the pipe
-	 */
-	socket *pipe();
+    /**
+     * @return pointer to the parent's end of the pipe
+     */
+    socket *pipe();
 
-	/**
-	 * @return const pointer to the parent's end of the pipe
-	 */
-	const socket *pipe() const;
+    /**
+     * @return const pointer to the parent's end of the pipe
+     */
+    const socket *pipe() const;
 
-	/**
-	 * Sends signal::stop to the actor thread.
-	 * The actor thread shall stop as soon as possible.
-	 * The return value is only relevant when block is true. If block is false (the default), this method
-	 * will return true.
-	 * 
-	 * It is safe to call stop() multiple time (to ask the actor to shutdown, and then a bit
-	 * later call stop(true) to make sure it is really stopped)
-	 * 
-	 * @note calling this method on an "empty" actor (after it was moved) will return
-	 * false and nothing will happen.
-	 * @param block whether or not we wait until the actor thread stops.
-	 * @return a boolean indicating whether or not the actor successfully shutdown.
-	 */
-	bool stop(bool block = false);
+    /**
+     * Sends signal::stop to the actor thread.
+     * The actor thread shall stop as soon as possible.
+     * The return value is only relevant when block is true. If block is false
+     * (the default), this method
+     * will return true.
+     *
+     * It is safe to call stop() multiple time (to ask the actor to shutdown,
+     * and then a bit
+     * later call stop(true) to make sure it is really stopped)
+     *
+     * @note calling this method on an "empty" actor (after it was moved) will
+     * return
+     * false and nothing will happen.
+     * @param block whether or not we wait until the actor thread stops.
+     * @return a boolean indicating whether or not the actor successfully
+     * shutdown.
+     */
+    bool stop(bool block = false);
 
-    private:
-	/**
-	 * Call a user defined function and performs cleanup once it returns.
-	 * We use a copy of child_pipe_ here; this is to avoid a race condition where the
-	 * destructor would be called before start_routine finishes but after it sent signal::ok / signal::ko.
-	 * The actor object would be invalid (because already destroyed).
-	 * 
-	 * @param child a copy of child_pipe_.
-	 * @param routine user routine that will be called
-	 */
-	void start_routine(socket *child, ActorStartRoutine routine);
+  private:
+    /**
+     * Call a user defined function and performs cleanup once it returns.
+     * We use a copy of child_pipe_ here; this is to avoid a race condition
+     * where the
+     * destructor would be called before start_routine finishes but after it
+     * sent signal::ok / signal::ko.
+     * The actor object would be invalid (because already destroyed).
+     *
+     * @param child a copy of child_pipe_.
+     * @param routine user routine that will be called
+     */
+    void start_routine(socket *child, ActorStartRoutine routine);
 
-         /**
-         * Bind the parent socket and return the endpoint used.
-         * Since endpoint are generated and have to be tested for availability
-         * this method is reponsible for finding a valid endpoint to bind to.
-         */
-	 std::string bind_parent();
+    /**
+    * Bind the parent socket and return the endpoint used.
+    * Since endpoint are generated and have to be tested for availability
+    * this method is responsible for finding a valid endpoint to bind to.
+    */
+    std::string bind_parent();
 
-	/**
-	 * The parent thread socket.
-	 * This socket will be closed and freed by the actor destructor.
-	 */
-	socket *parent_pipe_;
+    /**
+     * The parent thread socket.
+     * This socket will be closed and freed by the actor destructor.
+     */
+    socket *parent_pipe_;
 
-	/**
-	 * The child end of the pipe.
-	 * It is closed and freed when the routine ran by the actor ends.
-	 */
-	socket *child_pipe_;
+    /**
+     * The child end of the pipe.
+     * It is closed and freed when the routine ran by the actor ends.
+     */
+    socket *child_pipe_;
 
-	/**
-	 * This static, per process zmqpp::context, is used to connect PAIR socket
-	 * between Actor and their parent thread.
-	 */
-	static context actor_pipe_ctx_;
+    /**
+     * This static, per process zmqpp::context, is used to connect PAIR socket
+     * between Actor and their parent thread.
+     */
+    static context actor_pipe_ctx_;
 
-	/**
-	 * Keeps track of the status of the actor thread.
-	 */
-	bool stopped_;
+    /**
+     * Keeps track of the status of the actor thread.
+     */
+    bool stopped_;
 
-	bool retval_;
-    };
+    bool retval_;
+  };
 }

--- a/src/zmqpp/actor.hpp
+++ b/src/zmqpp/actor.hpp
@@ -12,6 +12,7 @@
 #include <thread>
 #include <functional>
 #include <mutex>
+#include <zmqpp/context.hpp>
 #include "socket.hpp"
 
 namespace zmqpp
@@ -109,6 +110,9 @@ namespace zmqpp
      * @param block whether or not we wait until the actor thread stops.
      * @return a boolean indicating whether or not the actor successfully
      * shutdown.
+     *
+     * @note Exception thrown during initialization (before sending ko/ok) are
+     *       rethrown in the actor's constructor.
      */
     bool stop(bool block = false);
 
@@ -150,6 +154,10 @@ namespace zmqpp
      * between Actor and their parent thread.
      */
     static context actor_pipe_ctx_;
+
+    mutable std::mutex mutex_;
+
+    std::exception_ptr eptr_;
 
     /**
      * Keeps track of the status of the actor thread.


### PR DESCRIPTION
The first commit is simply a reformatting to replace tabs by space and uniform this.

The second commit allows exceptions to propagate from actor thread to parent thread during actor initialization.
