### PR TITLE
Problem: No wrapper for zmq_proxy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set( LIBZMQPP_SOURCES
   src/zmqpp/zap_request.cpp
   src/zmqpp/auth.cpp
   src/zmqpp/zmqpp.cpp
+  src/zmqpp/proxy.cpp
   )
 
 # Staticlib
@@ -195,6 +196,7 @@ if( ZMQPP_BUILD_TESTS )
     src/tests/test_socket_options.cpp
     src/tests/test_z85.cpp
     src/tests/test_auth.cpp
+    src/tests/test_proxy.cpp
     )
   target_link_libraries( zmqpp-test-runner  ${LIB_TO_LINK_TO_EXAMPLES} ${Boost_LIBRARIES})
   add_test( zmqpp-test zmqpp-test-runner --log-level=test-suite )

--- a/src/tests/test_proxy.cpp
+++ b/src/tests/test_proxy.cpp
@@ -1,0 +1,53 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file is part of zmqpp.
+ * Copyright (c) 2011-2015 Contributors as noted in the AUTHORS file.
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <thread>
+#include "zmqpp/context.hpp"
+#include "zmqpp/message.hpp"
+#include "zmqpp/proxy.hpp"
+
+BOOST_AUTO_TEST_SUITE( proxy )
+
+BOOST_AUTO_TEST_CASE( simple_direction )
+{
+  zmqpp::context ctx;
+  zmqpp::socket puller(ctx, zmqpp::socket_type::pull);
+  zmqpp::socket pusher(ctx, zmqpp::socket_type::push);
+
+  pusher.connect(
+      "inproc://frontend"); // connect to the pull socket in the other thread
+  puller.connect("inproc://backend"); // ditto, push socket.
+
+  std::thread t1([&]()
+                 {
+                   zmqpp::socket sa(ctx, zmqpp::socket_type::pull);
+                   zmqpp::socket sb(ctx, zmqpp::socket_type::push);
+                   sa.bind("inproc://frontend");
+                   sb.bind("inproc://backend");
+                   zmqpp::proxy p(sa, sb);
+                 });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  zmqpp::message msg;
+  msg << "Hello";
+
+  pusher.send(msg);
+
+  std::string ret;
+  puller.receive(ret);
+  BOOST_CHECK_EQUAL("Hello", ret);
+
+  puller.close();
+  pusher.close();
+  ctx.terminate();
+  t1.join();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_proxy.cpp
+++ b/src/tests/test_proxy.cpp
@@ -15,15 +15,9 @@
 
 BOOST_AUTO_TEST_SUITE( proxy )
 
-BOOST_AUTO_TEST_CASE( simple_direction )
+BOOST_AUTO_TEST_CASE(simple_direction)
 {
   zmqpp::context ctx;
-  zmqpp::socket puller(ctx, zmqpp::socket_type::pull);
-  zmqpp::socket pusher(ctx, zmqpp::socket_type::push);
-
-  pusher.connect(
-      "inproc://frontend"); // connect to the pull socket in the other thread
-  puller.connect("inproc://backend"); // ditto, push socket.
 
   std::thread t1([&]()
                  {
@@ -35,6 +29,14 @@ BOOST_AUTO_TEST_CASE( simple_direction )
                  });
 
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  zmqpp::socket puller(ctx, zmqpp::socket_type::pull);
+  zmqpp::socket pusher(ctx, zmqpp::socket_type::push);
+
+  pusher.connect(
+      "inproc://frontend"); // connect to the pull socket in the other thread
+  puller.connect("inproc://backend"); // ditto, push socket.
+
   zmqpp::message msg;
   msg << "Hello";
 

--- a/src/zmqpp/proxy.cpp
+++ b/src/zmqpp/proxy.cpp
@@ -1,0 +1,22 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file is part of zmqpp.
+ * Copyright (c) 2011-2015 Contributors as noted in the AUTHORS file.
+ */
+
+#include "proxy.hpp"
+
+zmqpp::proxy::proxy(socket &sa, socket &sb)
+{
+  zmq_proxy(static_cast<void *>(sa), static_cast<void *>(sb), nullptr);
+}
+
+zmqpp::proxy::proxy(zmqpp::socket &sa, zmqpp::socket &sb,
+                    zmqpp::socket &capture)
+{
+  zmq_proxy(static_cast<void *>(sa), static_cast<void *>(sb),
+            static_cast<void *>(capture));
+}

--- a/src/zmqpp/proxy.hpp
+++ b/src/zmqpp/proxy.hpp
@@ -1,0 +1,42 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file is part of zmqpp.
+ * Copyright (c) 2011-2015 Contributors as noted in the AUTHORS file.
+ */
+
+#pragma once
+
+#include "socket.hpp"
+
+namespace zmqpp
+{
+  /**
+   * Provide a simple, non-steerable proxy that will bidirectionally
+   * forward traffic between socket A and B.
+   *
+   * If a *capture socket* is specified, the proxy shall send all messages,
+   * received on both frontend and backend, to the capture socket.
+   * The capture socket should be a ZMQ_PUB, ZMQ_DEALER, ZMQ_PUSH, or ZMQ_PAIR
+   * socket.
+   *
+   * @note This is wrapper around `zmq_proxy()`.
+   */
+  class proxy
+  {
+  public:
+    /**
+     * Construct a proxy that will forward traffic from
+     * A to B and from B to A.
+     */
+    proxy(socket &sa, socket &sb);
+
+    /**
+     * Construct a proxy that will forward traffic from A to B
+     * and from B to A as-well as sending a copy of all message to `capture`
+     */
+    proxy(socket &sa, socket &sb, socket &capture);
+  };
+}


### PR DESCRIPTION
Zmqpp didn't provide a wrapper around `zmq_proxy`. See #129 .

(This does not bring support to `zmq_proxy_steerable`)