### PR TITLE
Fix a low probability bug in ::send()

### DIFF
--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -179,7 +179,7 @@ bool socket::send(message& message, bool const dont_block /* = false */)
 
 			if(EINTR == zmq_errno())
 			{
-				if (0 == message.parts())
+				if (0 == i) // If first part of the message.
 				{
 					return false;
 				}


### PR DESCRIPTION
A ::send() marked unblocking, where the zmq[_send,_sendmsg,_ms_send]
  of the first (or only) part returned EINTR was expected to
  return FALSE (== would-block) to the caller, but instead would
  have sent the entire message. The comments indicate that this
  could lead to the send blocking.

This would not be visible in our code, apart from a failure to update
  statistics about blocked sends. These statistics are used to infer
  which parts of the processing pipeline is slow, and are not critical.

The bug was found by code inspection and no testcase has been written.