### PR TITLE
Problem: Cannot use inet.hpp on its own

### DIFF
--- a/src/zmqpp/inet.hpp
+++ b/src/zmqpp/inet.hpp
@@ -17,6 +17,8 @@
 #ifndef ZMQPP_INET_HPP_
 #define ZMQPP_INET_HPP_
 
+#include <utility>
+#include <cassert>
 #include <cstdint>
 
 /** \todo cross-platform version of including headers. */


### PR DESCRIPTION
We cannot use inet.hpp on its own because it is missing some includes.