### PR TITLE
Removes libsodim dependency from tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ CLIENT_LIBS = -L$(BUILD_PATH) \
 
 TEST_LIBS = -L$(BUILD_PATH) \
 	-l$(LIBRARY_NAME) \
-	-lsodium \
 	-lboost_unit_test_framework \
 	-lpthread
 


### PR DESCRIPTION
Problem: Since `libsodium/master` defaulted to `tweetnacl` for CURVE, the use of `libsodium` became optional. However, `Makefile` of this project still links to `libsodium`, which breaks the build of this bindings on a machine that does not have `libsodium` installed.

(Moreover, it appears that the link was redundant, since building `libzmq` with `libsodium` still succeeds.)