### PR TITLE
Avoid terminating NUL in socket::get(..., string&)

### DIFF
--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -791,7 +791,7 @@ void socket::get(socket_option const option, std::string& value) const
 			throw zmq_internal_exception();
 		}
 
-		value.assign(buffer.data(), size);
+		value.assign(buffer.data(), size > 0 ? size-1 : 0);
 		break;
 	default:
 		throw exception("attempting to get a non string option with a string value");


### PR DESCRIPTION
When reading a string value from zmq_getsockopt, it includes the terminating NUL character in the size. Which is reasonable since it's advertised as a buffer size. But when zmqpp turns that into a C++ string, the terminating null is inappropriate. This patch removes the terminating NUL.