### PR TITLE
Problem: Small issue with msvc not being able to find context.hpp in …

### DIFF
--- a/src/zmqpp/actor.hpp
+++ b/src/zmqpp/actor.hpp
@@ -12,7 +12,7 @@
 #include <thread>
 #include <functional>
 #include <mutex>
-#include <zmqpp/context.hpp>
+#include "context.hpp"
 #include "socket.hpp"
 
 namespace zmqpp


### PR DESCRIPTION
…actor.hpp

Fix: Change used include syntax

Please report if this breaks the builds of other compilers.