### PR TITLE
Export several classes in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set( LIBZMQPP_SOURCES
 # Staticlib
 if (ZMQPP_BUILD_STATIC)
   add_library( zmqpp-static STATIC ${LIBZMQPP_SOURCES})
+  target_compile_definitions(zmqpp-static PUBLIC ZMQ_STATIC ZMQPP_STATIC_DEFINE)
   if (NOT ZMQPP_LIBZMQ_CMAKE)
     find_library(ZEROMQ_LIBRARY_STATIC ${ZMQPP_LIBZMQ_NAME_STATIC} PATHS ${ZEROMQ_LIB_DIR})
     if (NOT ZEROMQ_LIBRARY_STATIC)
@@ -128,6 +129,10 @@ if (ZMQPP_BUILD_SHARED)
   list( APPEND INSTALL_TARGET_LIST zmqpp)
   set( LIB_TO_LINK_TO_EXAMPLES zmqpp )
 endif() # ZMQPP_BUILD_SHARED
+
+include(GenerateExportHeader)
+generate_export_header(zmqpp)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Examples
 # --------
@@ -210,3 +215,7 @@ install(TARGETS ${INSTALL_TARGET_LIST}
 
 install(DIRECTORY src/zmqpp DESTINATION include/
         FILES_MATCHING PATTERN "*.hpp")
+
+install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/zmqpp_export.h"
+        DESTINATION "include")

--- a/src/tests/test_sanity.cpp
+++ b/src/tests/test_sanity.cpp
@@ -13,7 +13,7 @@
  */
 
 // Module definition should only be in one of the tests
-#define BOOST_TEST_DYN_LINK
+//#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE zmqpp
 
 #include <boost/test/unit_test.hpp>

--- a/src/zmqpp/compatibility.hpp
+++ b/src/zmqpp/compatibility.hpp
@@ -117,6 +117,5 @@ namespace zmqpp
 #endif
 }
 
-
 #endif /* ZMQPP_COMPATIBILITY_HPP_ */
 

--- a/src/zmqpp/context.hpp
+++ b/src/zmqpp/context.hpp
@@ -21,6 +21,7 @@
 
 #include <zmq.h>
 
+#include "zmqpp_export.h"
 #include "compatibility.hpp"
 #include "exception.hpp"
 #if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
@@ -43,7 +44,7 @@ namespace zmqpp
  *
  * This class is c++0x move supporting and cannot be copied.
  */
-class context
+class ZMQPP_EXPORT context
 {
 public:
 

--- a/src/zmqpp/exception.hpp
+++ b/src/zmqpp/exception.hpp
@@ -22,6 +22,9 @@
 
 #include <zmq.h>
 
+#include "compatibility.hpp"
+#include "zmqpp_export.h"
+
 namespace zmqpp
 {
 
@@ -37,7 +40,7 @@ namespace zmqpp
  * The class extends std::runtime_error.
  *
  */
-class exception : public std::runtime_error
+class ZMQPP_EXPORT exception : public std::runtime_error
 {
 public:
 	/**
@@ -55,7 +58,7 @@ public:
  *
  * Objects may be invalid initially or after a shutdown or close.
  */
-class invalid_instance : public exception
+class ZMQPP_EXPORT invalid_instance : public exception
 {
 public:
 	invalid_instance(std::string const& message)
@@ -66,7 +69,7 @@ public:
     /**
      * Represents a failed zmqpp::actor initialization.
      */
-    class actor_initialization_exception : public exception
+    class ZMQPP_EXPORT actor_initialization_exception : public exception
     {
     public:
 
@@ -81,7 +84,7 @@ public:
    * Thrown when an error occurs while encoding or decoding to/from z85.
    * See ZMQ RFC 32
    */
-  class z85_exception : public exception
+  class ZMQPP_EXPORT z85_exception : public exception
   {
   public:
     z85_exception(const std::string &msg):
@@ -97,7 +100,7 @@ public:
  *
  * The class provides access to the zmq error number via zmq_error().
  */
-class zmq_internal_exception : public exception
+class ZMQPP_EXPORT zmq_internal_exception : public exception
 {
 public:
 	/**

--- a/src/zmqpp/frame.hpp
+++ b/src/zmqpp/frame.hpp
@@ -30,7 +30,7 @@ namespace zmqpp {
  * by the zmqpp message class to keep track of parts in the internal
  * queue. It is unlikely you need to use this class.
  */
-class frame
+class ZMQPP_EXPORT frame
 {
 public:
 	frame();

--- a/src/zmqpp/message.hpp
+++ b/src/zmqpp/message.hpp
@@ -40,7 +40,7 @@ namespace zmqpp
  * the target endpoints. zmq guarantees either the whole message or none
  * of the message will be delivered.
  */
-class message
+class ZMQPP_EXPORT message
 {
 public:
 	/**

--- a/src/zmqpp/poller.cpp
+++ b/src/zmqpp/poller.cpp
@@ -21,16 +21,6 @@
 namespace zmqpp
 {
 
-const long poller::wait_forever = -1;
-const short poller::poll_none   = 0;
-const short poller::poll_in     = ZMQ_POLLIN;
-const short poller::poll_out    = ZMQ_POLLOUT;
-const short poller::poll_error  = ZMQ_POLLERR;
-
-#if ((ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 2) || ZMQ_VERSION_MAJOR > 4)
-const short poller::poll_pri    = ZMQ_POLLPRI;
-#endif
-
 poller::poller()
 	: _items()
 	, _index()

--- a/src/zmqpp/poller.hpp
+++ b/src/zmqpp/poller.hpp
@@ -33,18 +33,18 @@ typedef socket socket_t;
  *
  * Allows access to polling for any number of zmq sockets or standard sockets.
  */
-class poller
+class ZMQPP_EXPORT poller
 {
 public:
-	static const long wait_forever; /*!< Block forever flag, default setting. */
+    static const long wait_forever = -1; /*!< Block forever flag, default setting. */
 
-	static const short poll_none;   /*!< No polling flags set. */
-	static const short poll_in;     /*!< Monitor inbound flag. */
-	static const short poll_out;    /*!< Monitor output flag. */
-	static const short poll_error;  /*!< Monitor error flag.\n Only for file descriptors. */
+    static const short poll_none = 0;   /*!< No polling flags set. */
+    static const short poll_in = ZMQ_POLLIN;     /*!< Monitor inbound flag. */
+    static const short poll_out = ZMQ_POLLOUT;    /*!< Monitor output flag. */
+    static const short poll_error = ZMQ_POLLERR;  /*!< Monitor error flag.\n Only for file descriptors. */
 
 #if ((ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 2) || ZMQ_VERSION_MAJOR > 4)
-        static const short poll_pri;    /*!< Priority input flag.\n Only for file descriptors. See POLLPRI) */
+        static const short poll_pri = ZMQ_POLLPRI;    /*!< Priority input flag.\n Only for file descriptors. See POLLPRI) */
 #endif
 
 	/**

--- a/src/zmqpp/signal.hpp
+++ b/src/zmqpp/signal.hpp
@@ -13,6 +13,8 @@
 #include <iostream>
 #include "compatibility.hpp"
 
+#include "zmqpp_export.h"
+
 namespace zmqpp
 {
 
@@ -50,5 +52,5 @@ namespace std
     /**
      * Write the value of the signal to the stream without removing the signal header..
      */
-    ostream &operator<<(ostream &s, const zmqpp::signal &sig);
+    ZMQPP_EXPORT ostream &operator<<(ostream &s, const zmqpp::signal &sig);
 }

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -25,17 +25,6 @@
 namespace zmqpp
 {
 
-const int socket::normal = 0;
-#if (ZMQ_VERSION_MAJOR == 2)
-const int socket::dont_wait = ZMQ_NOBLOCK;
-#else
-const int socket::dont_wait = ZMQ_DONTWAIT;
-#endif
-const int socket::send_more = ZMQ_SNDMORE;
-#ifdef ZMQ_EXPERIMENTAL_LABELS
-const int socket::send_label = ZMQ_SNDLABEL;
-#endif
-
 const int max_socket_option_buffer_size = 256;
 const int max_stream_buffer_size = 4096;
 

--- a/src/zmqpp/socket.hpp
+++ b/src/zmqpp/socket.hpp
@@ -72,18 +72,18 @@ namespace event
  *
  * This class is c++0x move supporting and cannot be copied.
  */
-class socket
+class ZMQPP_EXPORT socket
 {
 public:
-	static const int normal;                    /*!< /brief default send type, no flags set */
+    static const int normal = 0;                    /*!< /brief default send type, no flags set */
 #if (ZMQ_VERSION_MAJOR == 2)
-	static const int dont_wait;				    /*!< /brief don't block if sending is not currently possible  */
+    static const int dont_wait = ZMQ_NOBLOCK;				    /*!< /brief don't block if sending is not currently possible  */
 #else
-	static const int dont_wait;					/*!< /brief don't block if sending is not currently possible  */
+    static const int dont_wait = ZMQ_DONTWAIT;					/*!< /brief don't block if sending is not currently possible  */
 #endif
-	static const int send_more;					/*!< /brief more parts will follow this one */
+    static const int send_more = ZMQ_SNDMORE;					/*!< /brief more parts will follow this one */
 #ifdef ZMQ_EXPERIMENTAL_LABELS
-	static const int send_label;				/*!< /brief this message part is an internal zmq label */
+    static const int send_label = ZMQ_SNDLABEL;				/*!< /brief this message part is an internal zmq label */
 #endif
 
 	/**

--- a/src/zmqpp/zmqpp.hpp
+++ b/src/zmqpp/zmqpp.hpp
@@ -82,7 +82,7 @@ namespace zmqpp
  *
  * \return string version number.
  */
-std::string version();
+ZMQPP_EXPORT std::string version();
 
 /*!
  * Retrieve the parts of the zmqpp version number.
@@ -94,7 +94,7 @@ std::string version();
  * \param minor an unsigned 8 bit reference to set to the minor version.
  * \param revision an unsigned 8 bit reference to set the current revision.
  */
-void version(uint8_t& major, uint8_t& minor, uint8_t& revision);
+ZMQPP_EXPORT void version(uint8_t& major, uint8_t& minor, uint8_t& revision);
 
 /*!
  * Retrieve the parts of the 0mq version this library was built against.
@@ -110,7 +110,7 @@ void version(uint8_t& major, uint8_t& minor, uint8_t& revision);
  * \param minor an unsigned 8 bit reference to set to the minor version.
  * \param revision an unsigned 8 bit reference to set the current revision.
  */
-void zmq_version(uint8_t& major, uint8_t& minor, uint8_t& patch);
+ZMQPP_EXPORT void zmq_version(uint8_t& major, uint8_t& minor, uint8_t& patch);
 
 typedef context     context_t;   /*!< \brief context type */
 typedef std::string endpoint_t;  /*!< \brief endpoint type */


### PR DESCRIPTION
 - const static variables moved from source to header
 - export header generated by cmake