### PR TITLE
Support for ZMQ_USE_FD (available in zmq master for upcoming zmq 4.2)

### DIFF
--- a/src/tests/test_socket_options.cpp
+++ b/src/tests/test_socket_options.cpp
@@ -367,4 +367,15 @@ BOOST_AUTO_TEST_CASE( get_socket_options_tcp_only )
 //  CHECK_NOGET(socket, curve_server);
 }
 #endif
+#if (ZMQ_VERSION_MAJOR > 4) || ((ZMQ_VERSION_MAJOR == 4) && (ZMQ_VERSION_MINOR >= 2))
+BOOST_AUTO_TEST_CASE( use_fd_socket_option )
+{
+	zmqpp::context context;
+	zmqpp::socket socket(context, zmqpp::socket_type::push);
+	CHECK_GET(socket, int, use_fd);
+	CHECK_SET(socket, int, use_fd);
+	CHECK_GET(socket, int, use_fd);
+}
+#endif
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -475,21 +475,14 @@ void socket::set(socket_option const option, int const value)
 	case socket_option::tcp_keepalive_count:
 	case socket_option::tcp_keepalive_interval:
 #endif
-		if (0 != zmq_setsockopt(_socket, static_cast<int>(option), &value, sizeof(value)))
-		{
-			throw zmq_internal_exception();
-		}
-		break;
 #if (ZMQ_VERSION_MAJOR > 4) || ((ZMQ_VERSION_MAJOR == 4) && (ZMQ_VERSION_MINOR >= 2))
 	case socket_option::use_fd:
-	{
+#endif
 		if (0 != zmq_setsockopt(_socket, static_cast<int>(option), &value, sizeof(value)))
 		{
 			throw zmq_internal_exception();
 		}
 		break;
-	}
-#endif
 	default:
 		throw exception("attempting to set a non signed integer option with a signed integer value");
 	}
@@ -668,13 +661,6 @@ void socket::get(socket_option const option, int& value) const
 #endif
 #if (ZMQ_VERSION_MAJOR > 4) || ((ZMQ_VERSION_MAJOR == 4) && (ZMQ_VERSION_MINOR >= 2))
 	case socket_option::use_fd:
-		if (0 != zmq_getsockopt(_socket, static_cast<int>(option), &value, &value_size))
-		{
-			throw zmq_internal_exception();
-		}
-		// sanity check
-		assert(value_size <= sizeof(int));
-		break;
 #endif
 #if (ZMQ_VERSION_MAJOR >= 4)
 	case socket_option::ipv6:

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -529,6 +529,16 @@ void socket::set(socket_option const option, bool const value)
 		}
 		break;
 	}
+#if (ZMQ_VERSION_MAJOR > 4) || ((ZMQ_VERSION_MAJOR == 4) && (ZMQ_VERSION_MINOR >= 2))
+	case socket_option::use_fd:
+	{
+		if (0 != zmq_setsockopt(_socket, static_cast<int>(option), &value, sizeof(value)))
+		{
+			throw zmq_internal_exception();
+		}
+		break;
+	}
+#endif
 	default:
 		throw exception("attempting to set a non boolean option with a boolean value");
 	}
@@ -655,6 +665,16 @@ void socket::get(socket_option const option, int& value) const
 #endif
 #ifdef ZMQ_EXPERIMENTAL_LABELS
 	case socket_option::receive_label:
+#endif
+#if (ZMQ_VERSION_MAJOR > 4) || ((ZMQ_VERSION_MAJOR == 4) && (ZMQ_VERSION_MINOR >= 2))
+	case socket_option::use_fd:
+		if (0 != zmq_getsockopt(_socket, static_cast<int>(option), &value, &value_size))
+		{
+			throw zmq_internal_exception();
+		}
+		// sanity check
+		assert(value_size <= sizeof(int));
+		break;
 #endif
 #if (ZMQ_VERSION_MAJOR >= 4)
 	case socket_option::ipv6:

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -480,6 +480,16 @@ void socket::set(socket_option const option, int const value)
 			throw zmq_internal_exception();
 		}
 		break;
+#if (ZMQ_VERSION_MAJOR > 4) || ((ZMQ_VERSION_MAJOR == 4) && (ZMQ_VERSION_MINOR >= 2))
+	case socket_option::use_fd:
+	{
+		if (0 != zmq_setsockopt(_socket, static_cast<int>(option), &value, sizeof(value)))
+		{
+			throw zmq_internal_exception();
+		}
+		break;
+	}
+#endif
 	default:
 		throw exception("attempting to set a non signed integer option with a signed integer value");
 	}
@@ -529,16 +539,6 @@ void socket::set(socket_option const option, bool const value)
 		}
 		break;
 	}
-#if (ZMQ_VERSION_MAJOR > 4) || ((ZMQ_VERSION_MAJOR == 4) && (ZMQ_VERSION_MINOR >= 2))
-	case socket_option::use_fd:
-	{
-		if (0 != zmq_setsockopt(_socket, static_cast<int>(option), &value, sizeof(value)))
-		{
-			throw zmq_internal_exception();
-		}
-		break;
-	}
-#endif
 	default:
 		throw exception("attempting to set a non boolean option with a boolean value");
 	}

--- a/src/zmqpp/socket_options.hpp
+++ b/src/zmqpp/socket_options.hpp
@@ -109,6 +109,7 @@ ZMQPP_COMPARABLE_ENUM socket_option {
  #if (ZMQ_VERSION_MAJOR > 4) || ((ZMQ_VERSION_MAJOR == 4) && (ZMQ_VERSION_MINOR >= 2))
 	xpub_manual               = ZMQ_XPUB_MANUAL,
 	xpub_verboser             = ZMQ_XPUB_VERBOSER,
+	use_fd                    = ZMQ_USE_FD, /*!< Use a pre-allocated file descriptor instead of allocating a new one */
  #endif
 #endif // version > 2
 


### PR DESCRIPTION
This simple patch exposes the new ZMQ_USE_FD socket option of the upcoming zmq 4.2. This option is listed among experimental options ("draft"), but it was implemented already in February (https://github.com/zeromq/libzmq/commit/4bcbb3055ebf6753a2135fb3132311603d6ea930 and then renamed) so hopefuly it won't undergo any significant changes.

The support for this option is needed for the project I'm working on (scopes API in Ubuntu) and it would be great if it was accepted into the  zmqpp.