### PR TITLE
Fix compilation error with boost >= 1.60 - BOOST_CHECKPOINT has been …

### DIFF
--- a/src/tests/test_socket.cpp
+++ b/src/tests/test_socket.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE( socket_creation )
 BOOST_AUTO_TEST_CASE( socket_creation_bad_type )
 {
 	zmqpp::context context;
-	BOOST_CHECK_THROW(zmqpp::socket socket(context, static_cast<zmqpp::socket_type>(-1)), zmqpp::zmq_internal_exception)
+	BOOST_CHECK_THROW(zmqpp::socket socket(context, static_cast<zmqpp::socket_type>(-1)), zmqpp::zmq_internal_exception);
 }
 
 BOOST_AUTO_TEST_CASE( valid_socket )

--- a/src/tests/test_socket_options.cpp
+++ b/src/tests/test_socket_options.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_SUITE( socket_options )
 template<typename CheckType, typename WantedType>
 void try_set(zmqpp::socket& socket, zmqpp::socket_option const& option, CheckType const& value, std::string const& option_name, std::string const& value_type)
 {
-	BOOST_CHECKPOINT("setting option " << option_name << " against set type '" << value_type << "'");
+	BOOST_TEST_CHECKPOINT("setting option " << option_name << " against set type '" << value_type << "'");
 	try
 	{
 		socket.set(option, value);
@@ -51,7 +51,7 @@ void try_set(zmqpp::socket& socket, zmqpp::socket_option const& option, CheckTyp
 template<typename CheckType, typename WantedType>
 void try_get(zmqpp::socket const& socket, zmqpp::socket_option const& option, std::string const& option_name, std::string const& value_type)
 {
-	BOOST_CHECKPOINT("getting option " << option_name << " against set type '" << value_type << "'");
+	BOOST_TEST_CHECKPOINT("getting option " << option_name << " against set type '" << value_type << "'");
 	try
 	{
 		CheckType value;


### PR DESCRIPTION
…replaced by BOOST_TEST_CHECKPOINT. Add missing semicolon to test_socket.cpp.