### PR TITLE
Use -Wextra on compilers that aren't MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
 
 # Set compiler flags that don't work on Windows
 if(NOT MSVC)
-	list(APPEND CMAKE_CXX_FLAGS "-Wextra")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,12 @@ set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 # show all warnings
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
 
+# Set compiler flags that don't work on Windows
+if(NOT MSVC)
+	list(APPEND CMAKE_CXX_FLAGS "-Wextra")
+endif()
+
+
 # Set a consistent MACOSX_RPATH default across all CMake versions.  When CMake
 # 2.8.12 is required, change this default to 1.  When CMake 3.0.0 is required,
 # remove this block (see CMP0042).


### PR DESCRIPTION
This changes the edits in benjamg-patch-1 to conditionally use `-Wextra` if we aren't compiling on MSVC.