### PR TITLE
Cross platform endian conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,11 @@ if (ZMQPP_BUILD_SHARED)
   set( LIB_TO_LINK_TO_EXAMPLES zmqpp )
 endif() # ZMQPP_BUILD_SHARED
 
+# We need to link zmqpp to ws2_32 on windows for the implementation of winsock2.h
+if(WIN32)
+	target_link_libraries(zmqpp ws2_32)
+endif() # WIN32
+
 include(GenerateExportHeader)
 generate_export_header(zmqpp)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/src/zmqpp/byte_ordering.hpp
+++ b/src/zmqpp/byte_ordering.hpp
@@ -1,0 +1,45 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file is part of zmqpp.
+ * Copyright (c) 2011-2015 Contributors as noted in the AUTHORS file.
+ */
+
+/**
+ * \file
+ *
+ * \date   27 Sep 2016
+ * \author Daniel Underwood (@danielunderwood)
+ */
+
+#pragma once
+
+#if defined( __APPLE__) // Byte ordering on OS X
+
+#include <libkern/OSByteOrder.h>
+#define HOST_TO_BIG_ENDIAN_32(x) OSSwapHostToBigInt32(x)
+
+#elif defined(_WIN32) // Byte ordering on Windows
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+#include <winsock2.h>
+#define HOST_TO_BIG_ENDIAN_32(x) htonl(x)
+
+#elif BYTE_ORDER == BIG_ENDIAN
+#define HOST_TO_BIG_ENDIAN_32(x) (x)
+
+#endif
+
+#else // Let htobe32 be the default function
+
+#include <endian.h>
+#define HOST_TO_BIG_ENDIAN_32(x) htobe32(x)
+
+#endif
+
+// Cause a compiler error if the platform is not supported
+#ifndef HOST_TO_BIG_ENDIAN_32
+#error Platform not supported in byte_ordering.hpp
+#endif

--- a/src/zmqpp/zap_request.cpp
+++ b/src/zmqpp/zap_request.cpp
@@ -18,6 +18,7 @@
 #include "message.hpp"
 #include "socket.hpp"
 #include "z85.hpp"
+#include "byte_ordering.hpp"
 #include <unordered_map>
 #include <netinet/in.h>
 
@@ -108,7 +109,7 @@ std::vector<std::uint8_t> zap_request::serialize_metadata(
 
         // value length (4 OCTETs in network byte order)
         assert(pair.second.length() <= UINT32_MAX); // hm, really?
-        auto value_length = htobe32(static_cast<uint32_t>(pair.second.length()));
+        auto value_length = HOST_TO_BIG_ENDIAN_32(static_cast<uint32_t>(pair.second.length()));
         std::copy(reinterpret_cast<uint8_t*>(&value_length),
                   reinterpret_cast<uint8_t*>(&value_length) + 4,
                   std::back_inserter(metadata));


### PR DESCRIPTION
This change eliminates the call to `htobe32` which broke builds on OS X causing #164 and broke builds on Windows and possibly being related to #144. 

Endian byte ordering is moved to `byte_ordering.hpp` and defines a macro based on the platform being used. I only implemented host to big endian for 32 bits since that is the only call that seems to be used in the source code. Other conversions can be implemented if (or when) needed.