### PR TITLE
Respect the passed in length to socket::receive_raw

### DIFF
--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <cstring>
 #include <functional>
+#include <algorithm>
 
 #include "context.hpp"
 #include "exception.hpp"
@@ -340,7 +341,7 @@ bool socket::receive_raw(char* buffer, size_t& length, int const flags /* = NORM
 
 	if(result >= 0)
 	{
-		length = zmq_msg_size(&_recv_buffer);
+		length = std::min(length, zmq_msg_size(&_recv_buffer));
 		memcpy(buffer, zmq_msg_data(&_recv_buffer), length);
 
 		return true;


### PR DESCRIPTION
The receive_raw function is passed the maximum size of the buffer in the
length parameter.  The documentation states that the function will write
no more than this number of bytes.  Make sure that this is the case.

Also, add a test case that tests this.