### PR TITLE
Add function unmonitor to zmqpp::socket

### DIFF
--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -863,6 +863,16 @@ void socket::monitor(endpoint_t const monitor_endpoint, int events_required)
 		throw zmq_internal_exception();
 	}
 }
+
+void socket::unmonitor()
+{
+    int result = zmq_socket_monitor( _socket, NULL, 0 );
+
+	if (0 != result)
+	{
+		throw zmq_internal_exception();
+	}
+}
 #endif
 
 signal socket::wait()

--- a/src/zmqpp/socket.hpp
+++ b/src/zmqpp/socket.hpp
@@ -53,7 +53,7 @@ namespace event
 	const int closed           = ZMQ_EVENT_CLOSED;          /*<! connection closed */
 	const int close_failed     = ZMQ_EVENT_CLOSE_FAILED;    /*<! connection couldn't be closed */
 	const int disconnected     = ZMQ_EVENT_DISCONNECTED;    /*<! broken session */
-
+    const int monitor_stopped  = ZMQ_EVENT_MONITOR_STOPPED; /*<! this monitor socket will not receive event anymore */
 	const int all              = ZMQ_EVENT_ALL;             /*<! all event flags */
 }
 #endif
@@ -536,6 +536,14 @@ public:
 	 * \param events_required a bit mask of required events.
 	 */
 	void monitor(endpoint_t const monitor_endpoint, int events_required);
+
+	/**
+	 * Detach the monitor from this socket.
+	 *
+	 * \param monitor_endpoint the valid inproc endpoint to bind to.
+	 * \param events_required a bit mask of required events.
+	 */
+	void unmonitor();
 #endif
 
 	/**


### PR DESCRIPTION
Sockets can be unmonitored. This is not mentioned in documentation (which is pretty unclear), but the feature is implemented (https://github.com/zeromq/libzmq/blob/master/src/socket_base.cpp#L1592).

This merge add:
- the function zmqpp::socket::unmonitor,
- the event zmqpp::event::monitor_stopped (which is sent when unmonitor is called),
- test for unmonitor in test_socket.cpp.