### PR TITLE
This change eliminates the inclusion of "netinet/in.h" on Windows

### DIFF
--- a/src/zmqpp/zap_request.cpp
+++ b/src/zmqpp/zap_request.cpp
@@ -20,7 +20,10 @@
 #include "z85.hpp"
 #include "byte_ordering.hpp"
 #include <unordered_map>
+
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
 
 #if (ZMQ_VERSION_MAJOR > 3)
 


### PR DESCRIPTION
This change eliminates the inclusion of "netinet/in.h" on Windows, which does not exist on that platform. The inclusion of that file breaks Windows builds. I did not need to include "winsock2.h" to get a successful build.