### PR TITLE
change template method message::get(n) to const

### DIFF
--- a/src/zmqpp/message.hpp
+++ b/src/zmqpp/message.hpp
@@ -89,7 +89,7 @@ public:
 	// Warn: If a pointer type is requested the message (well zmq) still 'owns'
 	// the data and will release it when the message object is freed.
 	template<typename Type>
-	Type get(size_t const part)
+	Type get(size_t const part) const
 	{
 		Type value;
 		get(value, part);


### PR DESCRIPTION
According to current implementation, template method message::get(size_t) can be const method since the method change nothing in the object itself.
This patch just changes current template method to const and user can call the method for const zmqpp::message objects.