### PR TITLE
Add loop class based on czmq zloop

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Author: Krzysztof Rapacki <shauren.dev@gmail.com>
 Author: Prem Shankar Kumar <meprem@gmail.com>
 Author: Arnaud Kapp <kapp.arno@gmail.com>
 Author: Lionel Orry <lionel.orry@gmail.com>
+Author: Jakub Piskorz <piskorzj@gmail.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ set( LIBZMQPP_SOURCES
   src/zmqpp/context.cpp
   src/zmqpp/curve.cpp
   src/zmqpp/frame.cpp
+  src/zmqpp/loop.cpp
   src/zmqpp/message.cpp
   src/zmqpp/poller.cpp
   src/zmqpp/reactor.cpp
@@ -212,6 +213,7 @@ if( ZMQPP_BUILD_TESTS )
     src/tests/test_message_stream.cpp
     src/tests/test_poller.cpp
     src/tests/test_reactor.cpp
+    src/tests/test_loop.cpp
     src/tests/test_sanity.cpp
     src/tests/test_socket.cpp
     src/tests/test_socket_options.cpp

--- a/src/tests/test_loop.cpp
+++ b/src/tests/test_loop.cpp
@@ -1,0 +1,223 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file is part of zmqpp.
+ * Copyright (c) 2011-2015 Contributors as noted in the AUTHORS file.
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <thread>
+#include <exception>
+
+#include "zmqpp/context.hpp"
+#include "zmqpp/message.hpp"
+#include "zmqpp/loop.hpp"
+#include "zmqpp/socket.hpp"
+
+BOOST_AUTO_TEST_SUITE( loop )
+
+BOOST_AUTO_TEST_CASE(basic_usage)
+{
+    zmqpp::context context;
+
+    zmqpp::socket output(context, zmqpp::socket_type::pair);
+    output.bind("inproc://test");
+    zmqpp::socket input(context, zmqpp::socket_type::pair);
+    input.connect("inproc://test");
+
+    zmqpp::loop loop;
+
+    auto sendPing = [](zmqpp::socket & socket) -> bool { socket.send("PING"); return true; };
+    auto neverRun = []() -> bool { throw std::runtime_error("Not supposed to run"); return false; };
+
+    auto t1 = loop.add(std::chrono::milliseconds(1000), 1, neverRun);
+    loop.add(std::chrono::milliseconds(5), 1, [&loop, t1]() -> bool { loop.remove(t1); return true; });
+
+    loop.add(std::chrono::milliseconds(20), 1, std::bind(sendPing, std::ref(output)));
+
+    loop.add(std::chrono::milliseconds(2000), 1, neverRun);
+    loop.add(std::chrono::milliseconds(2000), 1, neverRun);
+    loop.add(std::chrono::milliseconds(2000), 1, neverRun);
+
+    loop.add(input, [&input]() -> bool { return false; });
+
+    BOOST_CHECK_NO_THROW(loop.start());
+}
+
+BOOST_AUTO_TEST_CASE(socket_removed_in_timer)
+{
+    zmqpp::context context;
+
+    zmqpp::socket output(context, zmqpp::socket_type::pair);
+    output.bind("inproc://test");
+    zmqpp::socket input(context, zmqpp::socket_type::pair);
+    input.connect("inproc://test");
+
+    zmqpp::loop loop;
+
+    bool socket_called = false;
+
+    loop.add(output, [&socket_called]() -> bool { socket_called = true; return false; });
+    loop.add(std::chrono::milliseconds(0), 1, [&loop, &output]() -> bool {
+        loop.remove(output);
+        loop.add(std::chrono::milliseconds(10), 1, []() -> bool { return false; });
+        return true;
+    });
+
+    input.send("PING");
+
+    BOOST_CHECK_NO_THROW(loop.start());
+    BOOST_CHECK(socket_called == false);
+}
+
+BOOST_AUTO_TEST_CASE(simple_pull_push)
+{
+    zmqpp::context context;
+
+    zmqpp::socket puller(context, zmqpp::socket_type::pull);
+    puller.bind("inproc://test");
+
+    zmqpp::socket pusher(context, zmqpp::socket_type::push);
+    pusher.connect("inproc://test");
+
+    BOOST_CHECK(pusher.send_raw("hello world!", sizeof ("hello world!")));
+
+    zmqpp::loop loop;
+    std::string message;
+    auto callable = [&message, &puller]() -> bool
+    {
+        BOOST_CHECK(puller.receive(message));
+        return true;
+    };
+
+    auto end_loop = []() -> bool { return false; };
+
+    loop.add(puller, callable);
+    loop.add(std::chrono::milliseconds(100), 1, end_loop);
+
+
+    BOOST_CHECK_NO_THROW(loop.start());
+
+    BOOST_CHECK_EQUAL("hello world!", message.c_str());
+    BOOST_CHECK(!puller.has_more_parts());
+}
+
+BOOST_AUTO_TEST_CASE(multiple_socket)
+{
+    zmqpp::context context;
+
+    zmqpp::socket pub(context, zmqpp::socket_type::pub);
+    pub.bind("inproc://test");
+
+    zmqpp::socket sub(context, zmqpp::socket_type::sub);
+    sub.connect("inproc://test");
+    sub.subscribe("hello");
+
+    zmqpp::socket sub2(context, zmqpp::socket_type::sub);
+    sub2.connect("inproc://test");
+    sub2.subscribe("hello");
+
+    BOOST_CHECK(pub.send("hello", zmqpp::socket::send_more));
+    BOOST_CHECK(pub.send("hello world!"));
+
+    zmqpp::loop loop;
+
+    int test1 = 0;
+    int test2 = 0;
+    int test3 = 0;
+    auto callable = [](int *value_to_update, int val) -> bool
+    {
+        *value_to_update = val;
+        return true;
+    };
+
+    auto end_loop = []() -> bool { return false; };
+
+    loop.add(sub, std::bind(callable, &test1, 1));
+    loop.add(sub2, std::bind(callable, &test2, 2));
+    loop.add(pub, std::bind(callable, &test3, 3), zmqpp::poller::poll_out);
+
+    loop.add(std::chrono::milliseconds(100), 1, end_loop);
+    BOOST_CHECK_NO_THROW(loop.start());
+
+    BOOST_CHECK_EQUAL(1, test1);
+    BOOST_CHECK_EQUAL(2, test2);
+    BOOST_CHECK_EQUAL(3, test3);
+
+
+    test1 = 0;
+    test2 = 0;
+    test3 = 0;
+
+    loop.remove(sub);
+
+    BOOST_CHECK(pub.send("hello", zmqpp::socket::send_more));
+    BOOST_CHECK(pub.send("hello world!"));
+
+    loop.add(std::chrono::milliseconds(100), 1, end_loop);
+    BOOST_CHECK_NO_THROW(loop.start());
+
+    BOOST_CHECK_EQUAL(0, test1);
+    BOOST_CHECK_EQUAL(2, test2);
+    BOOST_CHECK_EQUAL(3, test3);
+}
+
+BOOST_AUTO_TEST_CASE(remove_socket_in_handler)
+{
+    zmqpp::context context;
+
+    zmqpp::socket pub(context, zmqpp::socket_type::pub);
+    pub.bind("inproc://test");
+
+    zmqpp::socket sub(context, zmqpp::socket_type::sub);
+    sub.connect("inproc://test");
+    sub.subscribe("hello");
+
+    zmqpp::socket sub2(context, zmqpp::socket_type::sub);
+    sub2.connect("inproc://test");
+    sub2.subscribe("hello");
+
+    BOOST_CHECK(pub.send("hello", zmqpp::socket::send_more));
+    BOOST_CHECK(pub.send("hello world!"));
+
+    zmqpp::loop loop;
+    auto end_loop = []() -> bool { return false; };
+
+    int test1 = 0;
+    int test2 = 0;
+    auto callable = [&](int *value_to_update, int val) -> bool
+    {
+        if (val == 1)
+        {
+            loop.remove(sub);
+        }
+
+        *value_to_update = val;
+        return true;
+    };
+
+    loop.add(sub, std::bind(callable, &test1, 1));
+    loop.add(sub2, std::bind(callable, &test2, 2));
+
+    loop.add(std::chrono::milliseconds(100), 1, end_loop);
+    BOOST_CHECK_NO_THROW(loop.start());
+
+    BOOST_CHECK_EQUAL(1, test1);
+    BOOST_CHECK_EQUAL(2, test2);
+
+    test1 = test2 = 0;
+
+    BOOST_CHECK(pub.send("hello", zmqpp::socket::send_more));
+    BOOST_CHECK(pub.send("hello world!"));
+
+    loop.add(std::chrono::milliseconds(100), 1, end_loop);
+    BOOST_CHECK_NO_THROW(loop.start());
+
+    BOOST_CHECK_EQUAL(0, test1);
+    BOOST_CHECK_EQUAL(2, test2);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/zmqpp/loop.cpp
+++ b/src/zmqpp/loop.cpp
@@ -1,0 +1,236 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file is part of zmqpp.
+ * Copyright (c) 2011-2015 Contributors as noted in the AUTHORS file.
+ */
+
+/*
+ *  Created on: 20 Mar 2017
+ *      Author: Jakub Piskorz (@piskorzj)
+ */
+
+#include "exception.hpp"
+#include "socket.hpp"
+#include "loop.hpp"
+#include <algorithm>
+#include <zmq.h>
+
+namespace zmqpp
+{
+    loop::loop() :
+    dispatching_(false),
+    rebuild_poller_(false)
+    {
+    }
+
+    loop::~loop()
+    {
+    }
+
+    loop::timer_t::timer_t(size_t times, std::chrono::milliseconds delay) :
+    times(times),
+    delay(delay),
+    when(std::chrono::steady_clock::now() + delay)
+    {
+    }
+
+    void loop::timer_t::reset()
+    {
+         when = std::chrono::steady_clock::now() + delay;
+    }
+
+    void loop::timer_t::update()
+    {
+        when += delay;
+    }
+
+    void loop::add(socket& socket, Callable callable, short const event /* = POLL_IN */)
+    {
+        zmq_pollitem_t item{static_cast<void *> (socket), 0, event, 0};
+        add(item, callable);
+    }
+
+    void loop::add(raw_socket_t const descriptor, Callable callable, short const event /* = POLL_IN */)
+    {
+        zmq_pollitem_t item{nullptr, descriptor, event, 0};
+        add(item, callable);
+    }
+
+    void loop::add(const zmq_pollitem_t& item, Callable callable)
+    {
+        poller_.add(item);
+        rebuild_poller_ = true;
+        items_.push_back(std::make_pair(item, callable));
+    }
+
+    loop::timer_id_t loop::add(std::chrono::milliseconds delay, size_t times, Callable callable)
+    {
+        std::unique_ptr<timer_t> item(new timer_t(times, delay));
+        timer_id_t id = item.get();
+        add(std::move(item), callable);
+        return id;
+    }
+
+    void loop::add(std::unique_ptr<timer_t> item, Callable callable)
+    {
+        timers_.push_back(std::make_pair(std::move(item), callable));
+        timers_.sort(TimerItemCallablePairComp);
+    }
+
+    void loop::reset(timer_id_t const timer) {
+        for(auto &item : timers_) {
+            if(item.first.get() == timer) {
+                item.first->reset();
+                timers_.sort(TimerItemCallablePairComp);
+                return;
+            }
+        }
+    }
+
+    void loop::remove(timer_id_t const timer)
+    {
+        if(dispatching_)
+        {
+            timerRemoveLater_.push_back(timer);
+            return;
+        }
+        timers_.remove_if([&timer](const TimerItemCallablePair &pair) -> bool {
+            return pair.first.get() == timer;
+        });
+    }
+
+    void loop::remove(socket_t const& socket)
+    {
+        if (dispatching_)
+        {
+            rebuild_poller_ = true;
+            sockRemoveLater_.push_back(&socket);
+            return;
+        }
+        items_.erase(std::remove_if(items_.begin(), items_.end(), [&socket](const PollItemCallablePair & pair) -> bool
+        {
+            const zmq_pollitem_t &item = pair.first;
+            if (nullptr != item.socket && item.socket == static_cast<void *> (socket))
+            {
+                return true;
+            }
+            return false;
+        }), items_.end());
+        poller_.remove(socket);
+    }
+
+    void loop::remove(raw_socket_t const descriptor)
+    {
+        if (dispatching_)
+        {
+            rebuild_poller_ = true;
+            fdRemoveLater_.push_back(descriptor);
+            return;
+        }
+        items_.erase(std::remove_if(items_.begin(), items_.end(), [descriptor](const PollItemCallablePair & pair) -> bool
+        {
+            const zmq_pollitem_t &item = pair.first;
+            if (nullptr == item.socket && item.fd == descriptor)
+            {
+                return true;
+            }
+            return false;
+        }), items_.end());
+        poller_.remove(descriptor);
+    }
+
+    void loop::start()
+    {
+        while(1) {
+            rebuild_poller_ = false;
+            flush_remove_later();
+            bool poll_rc = poller_.poll(tickless());
+
+            dispatching_ = true;
+            bool continue_looping = start_handle_timers();
+            dispatching_ = false;
+
+            if(!continue_looping)
+                break;
+
+            if(rebuild_poller_)
+                continue;
+
+            dispatching_ = true;
+            if(poll_rc)
+                continue_looping = start_handle_poller();
+            dispatching_ = false;
+
+            if(!continue_looping)
+                break;
+        }
+        flush_remove_later();
+    }
+
+    bool loop::start_handle_timers()
+    {
+        std::chrono::steady_clock::time_point time_now = std::chrono::steady_clock::now();
+        auto it = timers_.begin();
+        while(it != timers_.end()) {
+            if((*it).first->when < time_now) {
+                bool timer_succedd = (*it).second();
+                if((*it).first->times && --(*it).first->times == 0) {
+                    it = timers_.erase(it);
+                } else {
+                    (*it).first->update();
+                    ++it;
+                }
+                if(!timer_succedd)
+                    return false;
+            } else
+                break;
+        }
+        timers_.sort(TimerItemCallablePairComp);
+        return true;
+    }
+
+    bool loop::start_handle_poller()
+    {
+        for (const PollItemCallablePair &pair : items_)
+        {
+            const zmq_pollitem_t &pollitem = pair.first;
+
+            if (poller_.has_input(pollitem) || poller_.has_error(pollitem) || poller_.has_output(pollitem))
+                if(!pair.second())
+                    return false;
+        }
+        return true;
+    }
+
+    void loop::flush_remove_later()
+    {
+        for (raw_socket_t fd : fdRemoveLater_)
+            remove(fd);
+        for (const socket_t *sock : sockRemoveLater_)
+            remove(*sock);
+        for (const timer_id_t & timer : timerRemoveLater_)
+            remove(timer);
+        fdRemoveLater_.clear();
+        sockRemoveLater_.clear();
+        timerRemoveLater_.clear();
+    }
+
+    long loop::tickless() {
+        std::chrono::steady_clock::time_point tick = std::chrono::steady_clock::now() + std::chrono::hours(1);
+        if(!timers_.empty() && timers_.front().first->when < tick)
+            tick = timers_.front().first->when;
+        long timeout = std::chrono::duration_cast<std::chrono::milliseconds>(tick - std::chrono::steady_clock::now()).count();
+        if(timeout < 0)
+            timeout = 0;
+        return timeout;
+    }
+
+    bool loop::TimerItemCallablePairComp(const TimerItemCallablePair &lhs, const TimerItemCallablePair &rhs)
+    {
+        return lhs.first->when < rhs.first->when;
+    }
+
+}

--- a/src/zmqpp/loop.hpp
+++ b/src/zmqpp/loop.hpp
@@ -1,0 +1,161 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file is part of zmqpp.
+ * Copyright (c) 2011-2015 Contributors as noted in the AUTHORS file.
+ */
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <list>
+#include <chrono>
+#include <functional>
+#include <memory>
+
+#include "compatibility.hpp"
+#include "poller.hpp"
+
+namespace zmqpp
+{
+
+    class socket;
+    typedef socket socket_t;
+
+    /**
+     * Loop object that helps to manage multiple socket by calling a user-defined handler for each socket
+     * when a watched event occurs.
+     * Calls assigned user-defined handler for timed events - repeaded and one-shot.
+     *
+     * It uses zmq::poller as the underlying polling mechanism.
+     */
+    class loop
+    {
+    public:
+        /**
+         * Type used to identify created timers withing loop
+         */
+        typedef void * timer_id_t;
+        typedef std::function<bool (void) > Callable;
+
+        /**
+         * Construct an empty polling model.
+         */
+        loop();
+
+        /**
+         * Cleanup reactor.
+         *
+         * Any sockets will need to be closed separately.
+         */
+        virtual ~loop();
+
+        /**
+         * Add a socket to the loop, providing a handler that will be called when the monitored events occur.
+         *
+         * \param socket the socket to monitor.
+         * \param callable the function that will be called by the loop when a registered event occurs on socket.
+         * \param event the event flags to monitor on the socket.
+         */
+        void add(socket_t& socket, Callable callable, short const event = poller::poll_in);
+
+        /*!
+         * Add a standard socket to the loop, providing a handler that will be called when the monitored events occur.
+         *
+         * \param descriptor the standard socket to monitor (SOCKET under Windows, a file descriptor otherwise).
+         * \param callable the function that will be called by the loop when a registered event occurs on fd.
+         * \param event the event flags to monitor.
+         */
+        void add(raw_socket_t const descriptor, Callable callable, short const event = poller::poll_in | poller::poll_error);
+
+        /**
+         * Add a timed event to the loop, providing a handler that will be called when timer fires.
+         *
+         * \param delay time after which handler will be executed.
+         * \param times how many times should timer be reneved - 0 for infinte ammount.
+         * \param callable the function that will be called by the loop after delay.
+         */
+        timer_id_t add(std::chrono::milliseconds delay, size_t times, Callable callable);
+
+        /**
+         * Reset timer in the loop, it will start counting delay time again. Times argument is preserved.
+         *
+         * \param timer identifier in the loop.
+         */
+        void reset(timer_id_t const timer);
+
+        /**
+         * Remove timer event from the loop.
+         *
+         * \param timer identifier in the loop.
+         */
+        void remove(timer_id_t const timer);
+
+        /**
+         * Stop monitoring a socket.
+         *
+         * \param socket the socket to stop monitoring.
+         */
+        void remove(socket_t const& socket);
+
+        /**
+         * Stop monitoring a standard socket.
+         *
+         * \param descriptor the standard socket to stop monitoring.
+         */
+        void remove(raw_socket_t const descriptor);
+
+        /**
+         * Starts loop. It will block until one of handlers returns false.
+         */
+        void start();
+
+    private:
+        struct timer_t {
+            size_t times;
+            std::chrono::milliseconds delay;
+            std::chrono::steady_clock::time_point when;
+
+            timer_t(size_t times, std::chrono::milliseconds delay);
+
+            void reset();
+            void update();
+        };
+
+        typedef std::pair<zmq_pollitem_t, Callable> PollItemCallablePair;
+        typedef std::pair<std::unique_ptr<timer_t>, Callable> TimerItemCallablePair;
+        static bool TimerItemCallablePairComp(const TimerItemCallablePair &lhs, const TimerItemCallablePair &rhs);
+
+        std::vector<PollItemCallablePair> items_;
+        std::list<TimerItemCallablePair> timers_;
+        std::vector<const socket_t *> sockRemoveLater_;
+        std::vector<raw_socket_t> fdRemoveLater_;
+        std::vector<timer_id_t> timerRemoveLater_;
+
+
+        void add(const zmq_pollitem_t &item, Callable callable);
+        void add(std::unique_ptr<timer_t>, Callable callable);
+
+        bool start_handle_timers();
+        bool start_handle_poller();
+
+        /**
+        * Flush the fdRemoveLater_ and sockRemoveLater_ vector, effectively removing
+        * the item for the reactor and poller.
+        */
+        void flush_remove_later();
+
+        /**
+        * Calculate min time to wait in poller.
+        */
+        long tickless();
+
+        poller poller_;
+        bool dispatching_;
+        bool rebuild_poller_;
+    };
+
+}

--- a/src/zmqpp/zmqpp.hpp
+++ b/src/zmqpp/zmqpp.hpp
@@ -66,6 +66,7 @@
 #include "socket.hpp"
 #include "actor.hpp"
 #include "reactor.hpp"
+#include "loop.hpp"
 #include "zap_request.hpp"
 #include "auth.hpp"
 


### PR DESCRIPTION
Hello, I'm big fan of zloop class in CZMQ project.
I started using reactor class but lack of timer functions was very inconvenient. It was hard to decide whether I should extend reactor class or add a new one. Finally, I decided to add a new one - following pattern in CZMQ project.

If this approach somehow not match your vision, please feel free to comment, it is not that hard to merge them together.

I've noticed that I forgot to put this on separate branch, that is why I closed #186 and opened new PR with separate feature branch.