### PR TITLE
4.2.0 requirements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,20 @@
 Development
 ===========
 
+Version 4.2.0
 
+* New add_nocopy and add_ncopy_const functions for messages to allow better raw
+  data handling.
+* Actor execption handling propergation fixed.
+* Support for 0mq 4.1 and 4.2 stable socket options and context options
+* Removed libsodium dependency for test code as it is no longer required for
+  0mq itself.
+* Fixed NUL from permaturely terminating a string value socket option response.
+* Support for removing parts of zmqpp::messages.
+* Better support for msvc and avoiding windows dll issues.
+* Non blocking functions default to bool type rather than integer flags.
+* Cross platform endianness conversion.
+* Code examples.
 
 Version 4.1.2
 =============

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ AR       = ar
 
 LIBRARY_NAME     = zmqpp
 VERSION_MAJOR    = 4
-VERSION_MINOR    = 1
-VERSION_REVISION = 2
+VERSION_MINOR    = 2
+VERSION_REVISION = 0
 
 #
 # Paths

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -443,7 +443,6 @@ void socket::set(socket_option const option, int const value)
 	case socket_option::xpub_manual:
 	case socket_option::xpub_nodrop:
 	case socket_option::xpub_verboser:
-	case socket_option::xpub_welcome_message:
 #endif
 		if (value == 0) { set(option, false); }
 		else if (value == 1) { set(option, true); }
@@ -546,7 +545,6 @@ void socket::set(socket_option const option, bool const value)
 	case socket_option::xpub_manual:
 	case socket_option::xpub_nodrop:
 	case socket_option::xpub_verboser:
-	case socket_option::xpub_welcome_message:
 #endif
 	{
 		int ivalue = value ? 1 : 0;
@@ -633,6 +631,7 @@ void socket::set(socket_option const option, char const* value, size_t const len
 	case socket_option::gssapi_principal:
 	case socket_option::gssapi_service_principal:
 	case socket_option::socks_proxy:
+	case socket_option::xpub_welcome_message:
 #endif
 		if (0 != zmq_setsockopt(_socket, static_cast<int>(option), value, length))
 		{
@@ -710,7 +709,6 @@ void socket::get(socket_option const option, int& value) const
 	case socket_option::vmci_connect_timeout:
 	case socket_option::xpub_manual:
 	case socket_option::xpub_nodrop:
-	case socket_option::xpub_welcome_message:
 #endif
 		if (0 != zmq_getsockopt(_socket, static_cast<int>(option), &value, &value_size))
 		{
@@ -766,7 +764,6 @@ void socket::get(socket_option const option, bool& value) const
 	case socket_option::xpub_manual:
 	case socket_option::xpub_nodrop:
 	case socket_option::xpub_verboser:
-	case socket_option::xpub_welcome_message:
 #endif
 		if (0 != zmq_getsockopt(_socket, static_cast<int>(option), &int_value, &value_size))
 		{

--- a/src/zmqpp/zmqpp.cpp
+++ b/src/zmqpp/zmqpp.cpp
@@ -39,4 +39,11 @@ void zmq_version(uint8_t& major, uint8_t& minor, uint8_t& patch)
 	patch = ZMQ_VERSION_PATCH;
 }
 
+#if (ZMQ_VERSION_MAJOR > 4) || ((ZMQ_VERSION_MAJOR == 4) && (ZMQ_VERSION_MINOR >= 1))
+bool has_capability(std::string const& capability)
+{
+	return 1 == zmq_has(capability.c_str());
+}
+#endif
+
 }

--- a/src/zmqpp/zmqpp.hpp
+++ b/src/zmqpp/zmqpp.hpp
@@ -113,6 +113,38 @@ ZMQPP_EXPORT void version(uint8_t& major, uint8_t& minor, uint8_t& revision);
  */
 ZMQPP_EXPORT void zmq_version(uint8_t& major, uint8_t& minor, uint8_t& patch);
 
+#if (ZMQ_VERSION_MAJOR > 4) || ((ZMQ_VERSION_MAJOR == 4) && (ZMQ_VERSION_MINOR >= 1))
+/*!
+ * Check for support in the underlaying 0mq library.
+ *
+ * This is a simple wrapper around the zmq_has capbaility check.
+ * Please see the 0mq documentation for a list of valid capabiliy strings.
+ */
+ZMQPP_EXPORT bool has_capability(std::string const& capability);
+
+/**
+ * The following methods are helper functions for the known capabilies
+ * that the underlaying 0mq service supports.
+ */
+
+/* Protcols */
+inline bool has_protocol_ipc() { return has_capability("ipc"); }
+inline bool has_protocol_pgm() { return has_capability("pgm"); }
+inline bool has_protocol_tipc() { return has_capability("tipc"); }
+inline bool has_protocol_norm() { return has_capability("norm"); }
+
+/* Security Mechanisms */
+inline bool has_security_curve() { return has_capability("curve"); }
+inline bool has_security_gssapi() { return has_capability("gssapi"); }
+
+/*!
+ * Check if the underlaying 0mq library was built with the draft api.
+ *
+ * \returns true if it was
+ */
+inline bool is_draft_api() { return has_capability("draft"); }
+#endif
+
 typedef context     context_t;   /*!< \brief context type */
 typedef std::string endpoint_t;  /*!< \brief endpoint type */
 typedef message     message_t;   /*!< \brief message type */


### PR DESCRIPTION
Minor fix plus update in prep for  #184 and tagging 4.2
Ideally we should finish the list from that issue but I don't see a nice way to handle things like routing ids which are per part in 0mq but would map to per message here. They should be the same on every part so it might be I'm just over thinking it.

At is stands I think we should tag and export to master at this point.