### PR TITLE
Fix #210 + Test cases : Get socket_option::identity returns wrong value

### DIFF
--- a/src/tests/test_socket.cpp
+++ b/src/tests/test_socket.cpp
@@ -508,6 +508,30 @@ BOOST_AUTO_TEST_CASE( test_signal_block_noblock )
     BOOST_CHECK_EQUAL(true, p2.receive(sig, true)); //noblock
 }
 
+
+BOOST_AUTO_TEST_CASE( simple_stream )
+{
+	zmqpp::context context;
+
+	zmqpp::socket s1(context, zmqpp::socket_type::stream);
+	zmqpp::socket s2(context, zmqpp::socket_type::stream);
+
+	s1.bind("inproc://test");
+	s2.connect("inproc://test");
+
+	std::string identity;
+	s2.get(zmqpp::socket_option::identity, identity);
+	zmqpp::message request;
+	request << identity;
+	request << "Hello world!";
+	BOOST_CHECK(s2.send(request));
+
+	zmqpp::message response;
+	BOOST_CHECK(s1.receive(response));
+	BOOST_CHECK(response.parts() == 2);
+	BOOST_CHECK(response.get(1) == "Hello world!");
+}
+
 #ifndef TRAVIS_CI_BUILD //do not run when building on travis-ci (this cause oom error and kill the test process)
 BOOST_AUTO_TEST_CASE( sending_large_messages_string )
 {

--- a/src/tests/test_socket.cpp
+++ b/src/tests/test_socket.cpp
@@ -508,7 +508,7 @@ BOOST_AUTO_TEST_CASE( test_signal_block_noblock )
     BOOST_CHECK_EQUAL(true, p2.receive(sig, true)); //noblock
 }
 
-
+#if (ZMQ_VERSION_MAJOR >= 4)
 BOOST_AUTO_TEST_CASE( simple_stream )
 {
 	zmqpp::context context;
@@ -531,6 +531,7 @@ BOOST_AUTO_TEST_CASE( simple_stream )
 	BOOST_CHECK(response.parts() == 2);
 	BOOST_CHECK(response.get(1) == "Hello world!");
 }
+#endif
 
 #ifndef TRAVIS_CI_BUILD //do not run when building on travis-ci (this cause oom error and kill the test process)
 BOOST_AUTO_TEST_CASE( sending_large_messages_string )

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -838,6 +838,12 @@ void socket::get(socket_option const option, std::string& value) const
 	switch(option)
 	{
 	case socket_option::identity:
+		if(0 != zmq_getsockopt(_socket, static_cast<int>(option), buffer.data(), &size))
+		{
+			throw zmq_internal_exception();
+		}
+		value.assign(buffer.data(), size);
+		break;
 #if (ZMQ_VERSION_MAJOR > 3) || ((ZMQ_VERSION_MAJOR == 3) && (ZMQ_VERSION_MINOR >= 2))
 	case socket_option::last_endpoint:
 #endif
@@ -858,15 +864,7 @@ void socket::get(socket_option const option, std::string& value) const
 		{
 			throw zmq_internal_exception();
 		}
-		// Handle special case : identity is not a null-terminated string
-		if(option == socket_option::identity)
-		{
-			value.assign(buffer.data(), size);
-		}
-		else
-		{
-			value = buffer.data();
-		}
+		value = buffer.data();
 		break;
 	default:
 		throw exception("attempting to get a non string option with a string value");

--- a/src/zmqpp/socket.cpp
+++ b/src/zmqpp/socket.cpp
@@ -858,8 +858,15 @@ void socket::get(socket_option const option, std::string& value) const
 		{
 			throw zmq_internal_exception();
 		}
-
-		value.assign(buffer.data(), size > 0 ? size-1 : 0);
+		// Handle special case : identity is not a null-terminated string
+		if(option == socket_option::identity)
+		{
+			value.assign(buffer.data(), size);
+		}
+		else
+		{
+			value = buffer.data();
+		}
 		break;
 	default:
 		throw exception("attempting to get a non string option with a string value");


### PR DESCRIPTION
Linked to issue #210 
The identity socket option is not a null-terminated string, as opposed to other string typed options. Its final character was removed when retrieving its value.
This pull request fixes it by handling socket_option::identity vs other socket options differently.
An additional test case is added to complement the current set & get test cases : set a value, retrieve it and compare. This is distinct from current set & get test cases, which are mainly aimed at checking value types and exceptions.

I added another test to cover my initial use case : stream socket, to enable communication to a non-zmq socket