### PR TITLE
Fix cmake "No project() command is present" and "implicitly converting 'bool' to 'STRING' type" warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@
 
 
 cmake_minimum_required(VERSION 2.8.12)
+project(zmqpp)
 enable_testing()
 
 # prepare C++11
@@ -60,7 +61,7 @@ set( ZEROMQ_LIB_DIR       ""      CACHE PATH "The library directory for libzmq" 
 set( ZEROMQ_INCLUDE_DIR   ""      CACHE PATH "The include directory for ZMQ" )
 
 # Build flags
-set( IS_TRAVIS_CI_BUILD   true    CACHE bool "Defines TRAVIS_CI_BUILD - Should the tests avoid running cases where memory is scarce." )
+set( IS_TRAVIS_CI_BUILD   true    CACHE BOOL "Defines TRAVIS_CI_BUILD - Should the tests avoid running cases where memory is scarce." )
 
 # Find zmq.h and add its dir to the includes
 find_path(ZEROMQ_INCLUDE zmq.h PATHS ${ZEROMQ_INCLUDE_DIR})


### PR DESCRIPTION
Fixes:
```
CMake Warning (dev) at libraries/zmqpp/CMakeLists.txt:63 (set):
implicitly converting 'bool' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
and
```
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
