### PR TITLE
Make $(BINDIR) before installing zmqpp binary to it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ endif
 ifeq ($(BUILD_STATIC),yes)
 	install -m 755 $(BUILD_PATH)/$(LIBRARY_ARCHIVE) $(LIBDIR)/$(LIBRARY_ARCHIVE)
 endif
-	if [ -f $(BUILD_PATH)/$(CLIENT_TARGET) ]; then install -m 755 $(BUILD_PATH)/$(CLIENT_TARGET) $(BINDIR); fi
+	if [ -f $(BUILD_PATH)/$(CLIENT_TARGET) ]; then mkdir -p $(BINDIR); install -m 755 $(BUILD_PATH)/$(CLIENT_TARGET) $(BINDIR); fi
 	$(LDCONFIG)
 	@echo "use make installcheck to test the install"
 


### PR DESCRIPTION
This may fix #237 where "Client installation installs 'zmqpp' executable as 'bin' instead of 'bin/zmqpp' where (PREFIX)/bin/ directory does not already exist"